### PR TITLE
Fix link to "Analysing Characteristics" tutorial

### DIFF
--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1,7 +1,7 @@
 Tutorials
 =========
 
-- `Analysing Characteristics of PageXML Archive <https://github.com/knaw-huc/pagexml/blob/master/notebooks/Demo-analysing-pagexml-characteristics.ipynb>`_
+- `Analysing Characteristics of PageXML Archive <https://github.com/knaw-huc/pagexml/blob/master/notebooks/Demo-analysing-scan-characteristics.ipynb>`_
 - `Reading and analysing archives with many PageXML files <https://github.com/knaw-huc/pagexml/blob/master/notebooks/Demo-reading-pagexml-files-from-archive.ipynb>`_
 - `Text search in PageXML files <https://github.com/knaw-huc/pagexml/blob/master/notebooks/Demo-text-search-simple.ipynb>`_
 - `Text Search in Line Format Files <https://github.com/knaw-huc/pagexml/blob/master/notebooks/Demo-text-search-in-pagexml-archive.ipynb>`_


### PR DESCRIPTION
The link was broken. I assume that this fix points to what was the intended target.

### To review:
- [ ] Check that the tutorial behind the fixed link is indeed the intended tutorial