### PR TITLE
fix empty textline in cell giving type-error

### DIFF
--- a/pagexml/model/pagexml_document_model.py
+++ b/pagexml/model/pagexml_document_model.py
@@ -532,7 +532,7 @@ class PageXMLTableCell(PageXMLDoc):
         self.lines: List[PageXMLTextLine] = lines if lines is not None else []
         # Initial value is concatenated text of lines, but can be overwritten by user
         # with e.g. interpreted/evaluated text
-        self.value = " ".join([line.text for line in self.lines])
+        self.value = " ".join([line.text or "" for line in self.lines])
         self.row = row
         self.col = col
         self.row_span = row_span


### PR DESCRIPTION
If a table contains an empty cell, it gives this error:

```
535 self.value = " ".join([line.text for line in self.lines])
    536 self.row = row
    537 self.col = col

TypeError: sequence item 0: expected str instance, NoneType found
```
this circumvents that by adding an empty string instead. I'm not sure if that's the best way of dealing with this, but it worked for my purposes.