### PR TITLE
Add scan page splitting and empty regions.

### DIFF
--- a/data/example-2.xml
+++ b/data/example-2.xml
@@ -1,0 +1,3252 @@
+<PcGts xmlns="http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15 http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15/pagecontent.xsd">
+  <Metadata>
+    <Creator>prov=READ-COOP:name=PyLaia@Transkribus:model_id=21087:version=0.0.1
+prov=University of Rostock/Institute of Mathematics/CITlab|PLANET AI GmbH/Tobias Gruening/tobias.gruening@planet-ai.de:name=de.uros.citlab.module.baseline2polygon.B2PSeamMultiOriented:v=2.6.6
+prov=University of Rostock/Institute of Mathematics/CITlab|PLANET AI GmbH/Tobias Gruening/tobias.gruening@planet-ai.de:name=/net_tf/LA73_249_0mod360.pb:de.uros.citlab.segmentation.CITlab_LA_ML:v=2.6.6
+Transkribus
+</Creator>
+    <Created>2020-09-16T15:35:29.558+02:00</Created>
+    <LastChange>2020-09-16T15:35:42.005+02:00</LastChange>
+  </Metadata>
+  <Page imageFilename="NL-AsnDA_0114.11_1_0138.jpg" imageWidth="4988" imageHeight="4032">
+    <ReadingOrder>
+      <OrderedGroup id="ro_1600263342357" caption="Regions reading order">
+        <RegionRefIndexed index="0" regionRef="r1"/>
+        <RegionRefIndexed index="1" regionRef="r2"/>
+        <RegionRefIndexed index="2" regionRef="r3"/>
+        <RegionRefIndexed index="3" regionRef="r4"/>
+        <RegionRefIndexed index="4" regionRef="r5"/>
+        <RegionRefIndexed index="5" regionRef="r6"/>
+        <RegionRefIndexed index="6" regionRef="r7"/>
+        <RegionRefIndexed index="7" regionRef="r8"/>
+        <RegionRefIndexed index="8" regionRef="r9"/>
+      </OrderedGroup>
+    </ReadingOrder>
+    <TextRegion orientation="0.0" id="r1" custom="readingOrder {index:0;}">
+      <Coords points="228,3064 228,3218 268,3218 268,3064"/>
+      <TextLine id="r1l1" custom="readingOrder {index:0;}">
+        <Coords points="221,3207 281,3182 268,3052 206,3056 221,3207"/>
+        <Baseline points="228,3168 268,3164"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+    </TextRegion>
+    <TextRegion orientation="0.0" id="r2" custom="readingOrder {index:1;}">
+      <Coords points="262,2532 262,2706 290,2706 290,2532"/>
+      <TextLine id="r2l1" custom="readingOrder {index:0;}">
+        <Coords points="273,2685 299,2624 253,2570 217,2619 273,2685"/>
+        <Baseline points="262,2656 290,2632"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+    </TextRegion>
+    <TextRegion orientation="0.0" id="r3" custom="readingOrder {index:2;}">
+      <Coords points="264,2244 264,3360 426,3360 426,2244"/>
+      <TextLine id="r3l1" custom="readingOrder {index:0;}">
+        <Coords points="256,2264 297,2262 331,2284 355,2275 348,2230 268,2195 246,2205 256,2264"/>
+        <Baseline points="270,2276 306,2266 342,2264"/>
+        <Word id="r3l1_w1">
+          <Coords points="248,2236 248,2296 269,2296 269,2236"/>
+          <TextEquiv>
+            <Unicode>5</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>5</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r3l2" custom="readingOrder {index:1;}">
+        <Coords points="254,2322 296,2327 318,2314 315,2266 252,2274 254,2322"/>
+        <Baseline points="264,2298 306,2296"/>
+        <Word id="r3l2_w1">
+          <Coords points="260,2257 260,2317 288,2317 288,2257"/>
+          <TextEquiv>
+            <Unicode>8</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>8</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r3l3" custom="readingOrder {index:2;}">
+        <Coords points="273,2530 309,2503 282,2435 240,2447 273,2530"/>
+        <Baseline points="278,2510 298,2502"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r3l4" custom="readingOrder {index:3;}">
+        <Coords points="342,2696 372,2648 341,2606 311,2654 342,2696"/>
+        <Baseline points="334,2666 358,2648"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r3l5" custom="readingOrder {index:4;}">
+        <Coords points="278,2648 329,2651 335,2606 283,2612 278,2648"/>
+        <Baseline points="288,2658 316,2662"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r3l6" custom="readingOrder {index:5;}">
+        <Coords points="306,2738 394,2735 405,2651 376,2645 333,2667 316,2658 306,2738"/>
+        <Baseline points="322,2708 353,2719 384,2716"/>
+        <Word id="r3l6_w1">
+          <Coords points="320,2678 320,2738 388,2738 388,2678"/>
+          <TextEquiv>
+            <Unicode>95</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>95</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r3l7" custom="readingOrder {index:6;}">
+        <Coords points="271,2787 331,2812 353,2740 289,2728 271,2787"/>
+        <Baseline points="288,2770 328,2782"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r3l8" custom="readingOrder {index:7;}">
+        <Coords points="268,2917 300,2919 341,2947 371,2935 371,2848 332,2843 268,2864 268,2917"/>
+        <Baseline points="280,2888 306,2888 333,2888 360,2888"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r3l9" custom="readingOrder {index:8;}">
+        <Coords points="265,3125 315,3154 356,3136 425,3187 449,3073 423,3049 394,3053 355,3026 330,3033 288,3010 265,3125"/>
+        <Baseline points="280,3104 309,3115 338,3128 367,3137 396,3136 426,3128"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r3l10" custom="readingOrder {index:9;}">
+        <Coords points="283,3189 323,3186 416,3257 434,3141 381,3158 338,3133 291,3141 283,3189"/>
+        <Baseline points="294,3198 313,3175 338,3169 363,3181 388,3196 414,3198"/>
+        <Word id="r3l10_w1">
+          <Coords points="300,3134 300,3194 398,3194 398,3134"/>
+          <TextEquiv>
+            <Unicode>17</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>17</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r3l11" custom="readingOrder {index:10;}">
+        <Coords points="254,3366 354,3353 349,3255 330,3254 289,3297 250,3295 254,3366"/>
+        <Baseline points="264,3342 290,3341 316,3339 342,3338"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+    </TextRegion>
+    <TextRegion orientation="0.0" id="r4" custom="readingOrder {index:3;}">
+      <Coords points="272,1592 272,1746 312,1746 312,1592"/>
+      <TextLine id="r4l1" custom="readingOrder {index:0;}">
+        <Coords points="263,1733 292,1746 326,1717 318,1642 254,1644 263,1733"/>
+        <Baseline points="272,1696 312,1692"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+    </TextRegion>
+    <TextRegion orientation="0.0" id="r5" custom="readingOrder {index:4;}">
+      <Coords points="330,1596 330,1882 386,1882 386,1596"/>
+      <TextLine id="r5l1" custom="readingOrder {index:0;}">
+        <Coords points="318,1696 360,1704 390,1740 437,1648 416,1617 364,1604 318,1696"/>
+        <Baseline points="330,1696 358,1708 386,1724"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r5l2" custom="readingOrder {index:1;}">
+        <Coords points="341,1858 388,1812 337,1725 281,1755 341,1858"/>
+        <Baseline points="340,1832 374,1812"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+    </TextRegion>
+    <TextRegion orientation="0.0" id="r6" custom="readingOrder {index:5;}">
+      <Coords points="362,2122 362,2276 382,2276 382,2122"/>
+      <TextLine id="r6l1" custom="readingOrder {index:0;}">
+        <Coords points="350,2228 391,2244 405,2176 378,2157 365,2154 350,2228"/>
+        <Baseline points="362,2222 382,2226"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+    </TextRegion>
+    <TextRegion orientation="0.0" id="r7" custom="readingOrder {index:6;}">
+      <Coords points="400,2096 400,2270 440,2270 440,2096"/>
+      <TextLine id="r7l1" custom="readingOrder {index:0;}">
+        <Coords points="373,2218 387,2240 432,2253 471,2189 411,2155 373,2218"/>
+        <Baseline points="400,2196 440,2220"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+    </TextRegion>
+    <TextRegion orientation="0.0" id="r8" custom="readingOrder {index:7;}">
+      <Coords points="690,530 690,3807 2548,3807 2548,530"/>
+      <TextLine id="r8l1" custom="readingOrder {index:0;}">
+        <Coords points="733,582 777,592 798,578 1031,581 1084,597 1141,582 1224,596 1283,582 1322,594 1430,583 1464,596 1480,583 1590,592 1609,608 1634,588 1659,599 1714,588 1744,602 1861,598 1888,582 2012,598 2046,587 2110,594 2181,638 2294,586 2559,603 2560,525 2509,532 2468,508 2425,536 2358,524 2314,554 2273,533 2200,549 2154,507 2079,486 2008,511 1966,493 1937,509 1889,483 1861,499 1714,494 1639,512 1561,494 1300,513 1226,511 1183,492 1144,508 1112,492 1011,515 970,489 951,503 935,489 814,484 734,507 733,582"/>
+        <Baseline points="744,570 834,572 924,572 1014,574 1104,574 1195,576 1285,576 1375,576 1465,577 1555,578 1646,578 1736,578 1826,578 1916,578 2006,578 2097,578 2187,578 2277,578 2367,578 2457,578 2548,578"/>
+        <Word id="r8l1_w1">
+          <Coords points="735,532 735,592 956,592 956,532"/>
+          <TextEquiv>
+            <Unicode>Voorts</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l1_w2">
+          <Coords points="1006,534 1006,594 1050,594 1050,534"/>
+          <TextEquiv>
+            <Unicode>in</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l1_w3">
+          <Coords points="1088,534 1088,594 1189,594 1189,534"/>
+          <TextEquiv>
+            <Unicode>doo</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l1_w4">
+          <Coords points="1283,536 1283,596 1377,596 1377,536"/>
+          <TextEquiv>
+            <Unicode>den</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l1_w5">
+          <Coords points="1447,538 1447,598 1781,598 1781,538"/>
+          <TextEquiv>
+            <Unicode>schuldeis</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l1_w6">
+          <Coords points="1812,538 1812,598 1938,598 1938,538"/>
+          <TextEquiv>
+            <Unicode>chen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l1_w7">
+          <Coords points="2001,538 2001,598 2285,598 2285,538"/>
+          <TextEquiv>
+            <Unicode>ledingen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l1_w8">
+          <Coords points="2335,538 2335,598 2398,598 2398,538"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l1_w9">
+          <Coords points="2430,538 2430,598 2518,598 2518,538"/>
+          <TextEquiv>
+            <Unicode>dor</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>Voorts in doo den schuldeis chen ledingen en dor</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l2" custom="readingOrder {index:1;}">
+        <Coords points="720,664 750,674 778,662 844,684 929,675 968,696 984,680 1036,683 1078,665 1206,668 1243,685 1291,667 1353,686 1378,670 1453,684 1467,671 1577,681 1660,668 1719,689 1740,669 1795,681 1836,669 1837,628 1713,629 1633,590 1580,633 1502,586 1401,604 1283,582 1236,609 1207,588 1168,595 1122,581 1058,626 1014,598 980,627 902,618 874,631 815,585 778,603 742,584 721,591 720,664"/>
+        <Baseline points="732,652 786,652 841,654 895,654 950,656 1005,656 1059,657 1114,658 1168,658 1223,658 1278,660 1332,660 1387,660 1441,660 1496,660 1551,660 1605,660 1660,662 1714,662 1769,662 1824,662"/>
+        <Word id="r8l2_w1">
+          <Coords points="737,612 737,672 830,672 830,612"/>
+          <TextEquiv>
+            <Unicode>den</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l2_w2">
+          <Coords points="895,618 895,678 1340,678 1340,618"/>
+          <TextEquiv>
+            <Unicode>demnrenvan</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l2_w3">
+          <Coords points="1391,620 1391,680 1818,680 1818,620"/>
+          <TextEquiv>
+            <Unicode>toegentaan.</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>den demnrenvan toegentaan.</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l3" custom="readingOrder {index:2;}">
+        <Coords points="700,773 911,748 934,771 975,755 996,771 1051,751 1150,754 1177,774 1211,763 1230,775 1292,752 1315,768 1338,752 1418,768 1466,757 1489,778 1585,758 1624,783 1644,767 1670,779 1709,760 1773,774 1793,758 1853,768 1867,756 1979,754 1993,766 2034,755 2084,778 2114,755 2130,771 2176,758 2201,774 2279,758 2380,797 2419,765 2556,764 2557,683 2525,672 2483,683 2467,667 2406,681 2364,664 2293,726 2245,684 2218,698 2179,687 2119,723 1991,667 1904,688 1849,720 1814,719 1771,678 1608,687 1597,675 1507,682 1494,668 1418,713 1354,720 1283,672 1242,685 1180,667 1120,680 1104,669 1056,694 987,680 971,696 877,672 827,695 793,672 731,665 701,669 700,773"/>
+        <Baseline points="712,742 803,744 895,744 986,746 1078,746 1170,746 1261,748 1353,748 1444,748 1536,748 1628,750 1719,750 1811,750 1902,750 1994,750 2086,750 2177,750 2269,750 2360,750 2452,750 2544,750"/>
+        <Word id="r8l3_w1">
+          <Coords points="701,703 701,763 834,763 834,703"/>
+          <TextEquiv>
+            <Unicode>dat</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l3_w2">
+          <Coords points="881,704 881,764 951,764 951,704"/>
+          <TextEquiv>
+            <Unicode>bij</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l3_w3">
+          <Coords points="1008,706 1008,766 1253,766 1253,706"/>
+          <TextEquiv>
+            <Unicode>gebreken</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l3_w4">
+          <Coords points="1282,708 1282,768 1386,768 1386,708"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l3_w5">
+          <Coords points="1432,708 1432,768 1485,768 1485,708"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l3_w6">
+          <Coords points="1503,710 1503,770 1758,770 1758,710"/>
+          <TextEquiv>
+            <Unicode>hurlijke</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l3_w7">
+          <Coords points="1828,710 1828,770 2159,770 2159,710"/>
+          <TextEquiv>
+            <Unicode>voldoenmy</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l3_w8">
+          <Coords points="2194,710 2194,770 2275,770 2275,710"/>
+          <TextEquiv>
+            <Unicode>den</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l3_w9">
+          <Coords points="2310,710 2310,770 2536,770 2536,710"/>
+          <TextEquiv>
+            <Unicode>hoofdom</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>dat bij gebreken van de hurlijke voldoenmy den hoofdom</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l4" custom="readingOrder {index:3;}">
+        <Coords points="715,883 743,886 851,843 997,848 1013,862 1043,837 1174,842 1219,865 1268,845 1421,852 1435,839 1455,855 1517,841 1685,858 1801,843 1875,859 1966,841 2040,862 2088,842 2129,858 2161,842 2186,858 2235,847 2262,865 2303,852 2354,868 2406,846 2422,862 2434,850 2528,851 2528,793 2425,820 2391,807 2352,816 2274,774 2235,792 2187,762 2079,778 2013,761 1930,807 1804,758 1774,774 1726,758 1667,778 1653,764 1625,782 1587,759 1520,809 1481,814 1424,800 1385,760 1291,774 1254,758 1179,776 1151,764 1112,800 1062,809 979,756 933,772 908,749 716,771 715,883"/>
+        <Baseline points="728,830 817,830 906,830 996,832 1085,832 1175,832 1264,832 1353,832 1443,834 1532,834 1622,834 1711,834 1800,834 1890,834 1979,836 2069,836 2158,836 2247,837 2337,838 2426,838 2516,840"/>
+        <Word id="r8l4_w1">
+          <Coords points="722,790 722,850 763,850 763,790"/>
+          <TextEquiv>
+            <Unicode>of</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l4_w2">
+          <Coords points="799,790 799,850 1047,850 1047,790"/>
+          <TextEquiv>
+            <Unicode>betaling</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l4_w3">
+          <Coords points="1094,792 1094,852 1183,852 1183,792"/>
+          <TextEquiv>
+            <Unicode>der</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l4_w4">
+          <Coords points="1218,792 1218,852 1401,852 1401,792"/>
+          <TextEquiv>
+            <Unicode>renten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l4_w5">
+          <Coords points="1431,794 1431,854 1490,854 1490,794"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l4_w6">
+          <Coords points="1537,794 1537,854 1780,854 1780,794"/>
+          <TextEquiv>
+            <Unicode>kosten,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l4_w7">
+          <Coords points="1803,794 1803,854 1857,854 1857,794"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l4_w8">
+          <Coords points="1904,796 1904,856 2318,856 2318,796"/>
+          <TextEquiv>
+            <Unicode>schuldeischer</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l4_w9">
+          <Coords points="2388,798 2388,858 2507,858 2507,798"/>
+          <TextEquiv>
+            <Unicode>zijne</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>of betaling der renten en kosten, de schuldeischer zijne</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l5" custom="readingOrder {index:4;}">
+        <Coords points="713,927 756,938 816,923 843,939 894,923 949,923 963,937 1022,926 1050,940 1112,929 1143,949 1327,927 1368,953 1414,928 1435,944 1487,928 1570,942 1719,931 1737,948 1774,932 1879,948 2028,928 2147,961 2220,929 2273,927 2344,946 2392,930 2440,949 2491,940 2491,848 2422,861 2406,845 2333,898 2303,881 2266,890 2246,872 2200,876 2150,844 2092,890 2047,873 2028,892 1973,882 1932,900 1877,859 1797,842 1694,860 1554,844 1497,880 1428,893 1346,840 1295,868 1263,849 1224,867 1171,842 1135,871 1094,841 1064,850 1043,837 928,893 713,883 713,927"/>
+        <Baseline points="724,912 811,914 899,916 987,918 1075,920 1163,920 1250,922 1338,922 1426,922 1514,922 1602,922 1689,924 1777,924 1865,924 1953,922 2041,922 2128,922 2216,922 2304,924 2392,924 2480,924"/>
+        <Word id="r8l5_w1">
+          <Coords points="718,873 718,933 887,933 887,873"/>
+          <TextEquiv>
+            <Unicode>even</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l5_w2">
+          <Coords points="928,877 928,937 979,937 979,877"/>
+          <TextEquiv>
+            <Unicode>of</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l5_w3">
+          <Coords points="1015,882 1015,942 1642,942 1642,882"/>
+          <TextEquiv>
+            <Unicode>uithertrijgenden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l5_w4">
+          <Coords points="1688,884 1688,944 1770,944 1770,884"/>
+          <TextEquiv>
+            <Unicode>bij</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l5_w5">
+          <Coords points="1801,884 1801,944 1929,944 1929,884"/>
+          <TextEquiv>
+            <Unicode>deze</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l5_w6">
+          <Coords points="2002,882 2002,942 2448,942 2448,882"/>
+          <TextEquiv>
+            <Unicode>onherroepelijk</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>even of uithertrijgenden bij deze onherroepelijk</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l6" custom="readingOrder {index:5;}">
+        <Coords points="1398,978 1439,976 1439,928 1398,928 1398,978"/>
+        <Baseline points="1408,960 1428,960"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l7" custom="readingOrder {index:6;}">
+        <Coords points="713,1014 813,1005 852,1035 891,1019 951,1063 987,1063 1040,1015 1059,1027 1166,1016 1182,1030 1207,1018 1223,1032 1260,1016 1338,1042 1393,1033 1411,1015 1604,1013 1618,1025 1638,1011 1716,1025 1909,1014 1941,1033 2021,1013 2108,1034 2170,1013 2518,1033 2534,1029 2534,951 2463,971 2418,941 2392,950 2379,936 2331,936 2314,948 2271,927 2062,979 2010,965 1904,969 1870,941 1737,947 1714,933 1703,945 1641,940 1620,956 1570,942 1526,976 1457,969 1361,985 1300,938 1261,927 1224,950 1196,936 1148,954 1109,933 1066,972 1015,974 949,923 919,941 871,936 832,971 713,977 713,1014"/>
+        <Baseline points="724,1000 813,1002 903,1002 993,1004 1083,1004 1173,1004 1263,1004 1353,1004 1443,1006 1533,1006 1623,1006 1712,1006 1802,1006 1892,1006 1982,1006 2072,1006 2162,1008 2252,1008 2342,1010 2432,1010 2522,1012"/>
+        <Word id="r8l7_w1">
+          <Coords points="727,962 727,1022 908,1022 908,962"/>
+          <TextEquiv>
+            <Unicode>wordt</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l7_w2">
+          <Coords points="971,964 971,1024 1351,1024 1351,964"/>
+          <TextEquiv>
+            <Unicode>gemachtigd</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l7_w3">
+          <Coords points="1407,966 1407,1026 1544,1026 1544,966"/>
+          <TextEquiv>
+            <Unicode>met</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l7_w4">
+          <Coords points="1600,966 1600,1026 1837,1026 1837,966"/>
+          <TextEquiv>
+            <Unicode>macht</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l7_w5">
+          <Coords points="1906,966 1906,1026 2018,1026 2018,966"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l7_w6">
+          <Coords points="2062,968 2062,1028 2405,1028 2405,968"/>
+          <TextEquiv>
+            <Unicode>subitieutie</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l7_w7">
+          <Coords points="2449,971 2449,1031 2511,1031 2511,971"/>
+          <TextEquiv>
+            <Unicode>om</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>wordt gemachtigd met macht van subitieutie om</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l8" custom="readingOrder {index:7;}">
+        <Coords points="712,1107 847,1100 881,1117 913,1103 939,1121 952,1107 1003,1105 1037,1124 1078,1105 1124,1126 1152,1101 1216,1101 1246,1117 1271,1098 1360,1103 1374,1117 1493,1103 1566,1154 1653,1101 1896,1115 1915,1101 1970,1117 2022,1101 2093,1136 2132,1111 2176,1127 2251,1113 2306,1150 2412,1154 2483,1099 2540,1120 2540,1028 2476,1042 2433,1024 2375,1049 2352,1028 2242,1017 2180,1042 2125,1028 2087,1062 1949,1053 1867,1067 1812,1058 1757,1023 1667,1012 1640,1035 1619,1023 1582,1035 1544,1016 1486,1023 1443,1067 1390,1069 1294,1018 1250,1037 1209,1018 1184,1037 1124,1020 1094,1043 1058,1043 1030,1023 987,1064 959,1068 918,1055 895,1066 781,1011 746,1039 712,1034 712,1107"/>
+        <Baseline points="724,1090 814,1091 904,1092 994,1092 1084,1092 1175,1092 1265,1092 1355,1092 1445,1092 1535,1092 1626,1092 1716,1092 1806,1092 1896,1092 1986,1092 2077,1092 2167,1092 2257,1092 2347,1092 2437,1094 2528,1094"/>
+        <Word id="r8l8_w1">
+          <Coords points="724,1050 724,1110 816,1110 816,1050"/>
+          <TextEquiv>
+            <Unicode>het</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l8_w2">
+          <Coords points="879,1052 879,1112 1248,1112 1248,1052"/>
+          <TextEquiv>
+            <Unicode>versondene</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l8_w3">
+          <Coords points="1317,1052 1317,1112 1386,1112 1386,1052"/>
+          <TextEquiv>
+            <Unicode>in</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l8_w4">
+          <Coords points="1438,1052 1438,1112 1524,1112 1524,1052"/>
+          <TextEquiv>
+            <Unicode>het</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l8_w5">
+          <Coords points="1587,1052 1587,1112 1870,1112 1870,1052"/>
+          <TextEquiv>
+            <Unicode>openbaan</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l8_w6">
+          <Coords points="1939,1052 1939,1112 2106,1112 2106,1052"/>
+          <TextEquiv>
+            <Unicode>naar</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l8_w7">
+          <Coords points="2146,1052 2146,1112 2502,1112 2502,1052"/>
+          <TextEquiv>
+            <Unicode>plaatselijke</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>het versondene in het openbaan naar plaatselijke</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l9" custom="readingOrder {index:8;}">
+        <Coords points="720,1202 766,1186 835,1207 853,1189 906,1187 931,1208 947,1194 982,1210 1030,1185 1085,1213 1153,1186 1250,1209 1291,1186 1399,1212 1438,1189 1538,1208 1605,1186 1653,1209 1680,1186 1710,1207 1763,1189 1786,1200 1804,1187 1887,1189 1907,1201 1928,1187 1987,1201 2013,1188 2045,1190 2079,1222 2173,1225 2221,1200 2255,1226 2283,1226 2379,1185 2448,1217 2503,1209 2503,1158 2221,1154 2141,1110 2093,1147 2059,1151 2018,1114 1979,1146 1907,1153 1859,1132 1832,1152 1793,1136 1747,1152 1639,1135 1626,1149 1594,1142 1557,1156 1520,1126 1500,1146 1305,1150 1266,1111 1216,1101 1152,1101 1126,1126 1094,1114 1021,1123 1003,1105 968,1121 916,1107 874,1118 838,1102 778,1147 721,1147 720,1202"/>
+        <Baseline points="732,1174 820,1174 908,1174 996,1176 1084,1176 1172,1176 1260,1176 1348,1176 1436,1178 1524,1178 1612,1178 1700,1178 1788,1180 1876,1180 1964,1180 2052,1180 2140,1180 2228,1182 2316,1182 2404,1182 2492,1182"/>
+        <Word id="r8l9_w1">
+          <Coords points="727,1134 727,1194 1027,1194 1027,1134"/>
+          <TextEquiv>
+            <Unicode>getuiken</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l9_w2">
+          <Coords points="1096,1136 1096,1196 1135,1196 1135,1136"/>
+          <TextEquiv>
+            <Unicode>te</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l9_w3">
+          <Coords points="1191,1136 1191,1196 1333,1196 1333,1136"/>
+          <TextEquiv>
+            <Unicode>doen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l9_w4">
+          <Coords points="1406,1138 1406,1198 1768,1198 1768,1138"/>
+          <TextEquiv>
+            <Unicode>verkoopen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l9_w5">
+          <Coords points="1832,1140 1832,1200 1905,1200 1905,1140"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l9_w6">
+          <Coords points="1935,1140 1935,1200 1995,1200 1995,1140"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l9_w7">
+          <Coords points="2060,1142 2060,1202 2477,1202 2477,1142"/>
+          <TextEquiv>
+            <Unicode>kooppennin</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>getuiken te doen verkoopen en de kooppennin</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l10" custom="readingOrder {index:9;}">
+        <Coords points="729,1319 797,1287 823,1298 866,1273 937,1287 1082,1276 1159,1297 1320,1276 1352,1297 1400,1276 1428,1292 1476,1279 1494,1295 1515,1276 1535,1290 1551,1277 1602,1290 1705,1277 1748,1291 1831,1277 1870,1298 1900,1277 2010,1293 2133,1278 2188,1303 2246,1285 2280,1303 2314,1280 2349,1299 2369,1280 2516,1280 2516,1214 2450,1219 2390,1191 2351,1195 2266,1239 2225,1198 2161,1236 2127,1216 2092,1227 2021,1202 1934,1241 1806,1185 1787,1201 1666,1201 1638,1229 1600,1226 1583,1242 1517,1228 1501,1242 1464,1235 1432,1203 1412,1203 1370,1233 1226,1230 1210,1244 1134,1207 1043,1237 947,1198 880,1241 775,1225 759,1239 729,1234 729,1319"/>
+        <Baseline points="740,1266 828,1266 916,1266 1004,1268 1092,1268 1181,1268 1269,1269 1357,1270 1445,1270 1533,1270 1622,1270 1710,1270 1798,1270 1886,1270 1974,1270 2063,1270 2151,1270 2239,1270 2327,1270 2415,1268 2504,1268"/>
+        <Word id="r8l10_w1">
+          <Coords points="729,1226 729,1286 822,1286 822,1226"/>
+          <TextEquiv>
+            <Unicode>gen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l10_w2">
+          <Coords points="884,1226 884,1286 921,1286 921,1226"/>
+          <TextEquiv>
+            <Unicode>te</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l10_w3">
+          <Coords points="983,1228 983,1288 1305,1288 1305,1228"/>
+          <TextEquiv>
+            <Unicode>ontvangen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l10_w4">
+          <Coords points="1362,1230 1362,1290 1461,1290 1461,1230"/>
+          <TextEquiv>
+            <Unicode>ten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l10_w5">
+          <Coords points="1492,1230 1492,1290 1673,1290 1673,1230"/>
+          <TextEquiv>
+            <Unicode>einde</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l10_w6">
+          <Coords points="1741,1230 1741,1290 2016,1290 2016,1230"/>
+          <TextEquiv>
+            <Unicode>daaruit</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l10_w7">
+          <Coords points="2078,1230 2078,1290 2125,1290 2125,1230"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l10_w8">
+          <Coords points="2172,1230 2172,1290 2467,1290 2467,1230"/>
+          <TextEquiv>
+            <Unicode>koopdsom</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>gen te ontvangen ten einde daaruit de koopdsom</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l11" custom="readingOrder {index:10;}">
+        <Coords points="693,1367 744,1361 778,1388 821,1393 842,1375 911,1387 936,1366 991,1374 1005,1360 1108,1390 1234,1359 1367,1378 1404,1378 1422,1362 1477,1376 1754,1364 1791,1383 1855,1362 1919,1379 1954,1363 2043,1384 2043,1302 1982,1281 1901,1280 1793,1321 1716,1284 1672,1313 1633,1283 1606,1297 1510,1278 1493,1294 1466,1280 1408,1323 1301,1325 1257,1293 1234,1302 1202,1285 1117,1326 1024,1319 960,1282 836,1286 822,1299 799,1285 733,1324 694,1324 693,1367"/>
+        <Baseline points="706,1350 772,1350 838,1350 904,1350 971,1350 1037,1350 1103,1350 1170,1350 1236,1352 1302,1352 1369,1352 1435,1353 1501,1354 1567,1354 1634,1354 1700,1354 1766,1356 1833,1356 1899,1356 1965,1356 2032,1354"/>
+        <Word id="r8l11_w1">
+          <Coords points="708,1310 708,1370 975,1370 975,1310"/>
+          <TextEquiv>
+            <Unicode>alsmede</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l11_w2">
+          <Coords points="1046,1310 1046,1370 1243,1370 1243,1310"/>
+          <TextEquiv>
+            <Unicode>renten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l11_w3">
+          <Coords points="1294,1312 1294,1372 1359,1372 1359,1312"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l11_w4">
+          <Coords points="1415,1314 1415,1374 1597,1374 1597,1314"/>
+          <TextEquiv>
+            <Unicode>kosten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l11_w5">
+          <Coords points="1657,1314 1657,1374 1698,1374 1698,1314"/>
+          <TextEquiv>
+            <Unicode>te</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l11_w6">
+          <Coords points="1759,1316 1759,1376 2046,1376 2046,1316"/>
+          <TextEquiv>
+            <Unicode>verhalen.</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>alsmede renten en kosten te verhalen.</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l12" custom="readingOrder {index:11;}">
+        <Coords points="701,1453 910,1467 935,1449 962,1458 1038,1442 1079,1468 1114,1468 1146,1447 1276,1459 1292,1448 1460,1448 1508,1460 1588,1446 1618,1469 1675,1446 1689,1458 1753,1447 1812,1474 1854,1447 1890,1463 1984,1447 2021,1473 2058,1450 2083,1462 2106,1446 2147,1464 2200,1441 2261,1460 2275,1446 2383,1458 2454,1447 2493,1472 2507,1470 2507,1401 2440,1387 2397,1403 2335,1391 2289,1416 2241,1398 2207,1414 2159,1402 2108,1413 1996,1365 1920,1379 1842,1362 1794,1383 1723,1366 1627,1382 1600,1373 1563,1389 1519,1373 1478,1384 1439,1363 1405,1377 1313,1363 1256,1370 1215,1411 1153,1413 1132,1399 1091,1413 1018,1371 1004,1385 937,1366 921,1378 843,1375 820,1393 779,1389 729,1359 701,1370 701,1453"/>
+        <Baseline points="712,1434 801,1436 890,1436 979,1436 1068,1436 1158,1436 1247,1436 1336,1438 1425,1438 1514,1438 1604,1440 1693,1440 1782,1440 1871,1440 1960,1440 2050,1440 2139,1440 2228,1440 2317,1440 2406,1440 2496,1438"/>
+        <Word id="r8l12_w1">
+          <Coords points="716,1394 716,1454 783,1454 783,1394"/>
+          <TextEquiv>
+            <Unicode>5.</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l12_w2">
+          <Coords points="825,1396 825,1456 925,1456 925,1396"/>
+          <TextEquiv>
+            <Unicode>dit</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l12_w3">
+          <Coords points="984,1396 984,1456 997,1456 997,1396"/>
+          <TextEquiv>
+            <Unicode>i</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l12_w4">
+          <Coords points="1093,1396 1093,1456 1261,1456 1261,1396"/>
+          <TextEquiv>
+            <Unicode>gevel</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l12_w5">
+          <Coords points="1353,1398 1353,1458 1454,1458 1454,1398"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l12_w6">
+          <Coords points="1517,1400 1517,1460 1794,1460 1794,1400"/>
+          <TextEquiv>
+            <Unicode>willigen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l12_w7">
+          <Coords points="1840,1400 1840,1460 2071,1460 2071,1400"/>
+          <TextEquiv>
+            <Unicode>verkoop</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l12_w8">
+          <Coords points="2117,1400 2117,1460 2260,1460 2260,1400"/>
+          <TextEquiv>
+            <Unicode>geene</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l12_w9">
+          <Coords points="2302,1400 2302,1460 2457,1460 2457,1400"/>
+          <TextEquiv>
+            <Unicode>ruive</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>5. dit i gevel van willigen verkoop geene ruive</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l13" custom="readingOrder {index:12;}">
+        <Coords points="702,1537 741,1528 824,1556 863,1540 897,1574 931,1581 1037,1570 1050,1582 1076,1564 1098,1580 1183,1583 1236,1532 1298,1544 1348,1533 1367,1549 1394,1533 1438,1561 1467,1541 1578,1530 1628,1546 1646,1535 1811,1540 1852,1577 1887,1586 1994,1578 2054,1539 2111,1549 2210,1533 2267,1538 2331,1573 2423,1543 2496,1539 2497,1459 2433,1449 2410,1472 2375,1458 2343,1479 2297,1449 2249,1464 2192,1441 2146,1464 2073,1459 2022,1498 1997,1500 1922,1449 1853,1501 1761,1453 1718,1457 1679,1496 1651,1503 1576,1454 1530,1472 1459,1449 1386,1446 1294,1466 1278,1455 1236,1473 1156,1468 1119,1498 1048,1497 987,1446 959,1474 886,1457 790,1459 741,1486 702,1488 702,1537"/>
+        <Baseline points="714,1520 802,1520 891,1520 979,1521 1068,1522 1156,1522 1245,1522 1333,1523 1422,1524 1510,1524 1599,1524 1687,1525 1776,1526 1864,1526 1953,1526 2041,1526 2130,1528 2218,1528 2307,1528 2395,1528 2484,1528"/>
+        <Word id="r8l13_w1">
+          <Coords points="719,1480 719,1540 876,1540 876,1480"/>
+          <TextEquiv>
+            <Unicode>ring</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l13_w2">
+          <Coords points="917,1480 917,1540 965,1540 965,1480"/>
+          <TextEquiv>
+            <Unicode>of</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l13_w3">
+          <Coords points="1000,1482 1000,1542 1492,1542 1492,1482"/>
+          <TextEquiv>
+            <Unicode>vorgrelukking</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l13_w4">
+          <Coords points="1540,1484 1540,1544 1650,1544 1650,1484"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l13_w5">
+          <Coords points="1690,1485 1690,1545 1814,1545 1814,1485"/>
+          <TextEquiv>
+            <Unicode>deze</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l13_w6">
+          <Coords points="1882,1486 1882,1546 2183,1546 2183,1486"/>
+          <TextEquiv>
+            <Unicode>Ryputheek</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l13_w7">
+          <Coords points="2252,1488 2252,1548 2341,1548 2341,1488"/>
+          <TextEquiv>
+            <Unicode>zal</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l13_w8">
+          <Coords points="2382,1488 2382,1548 2484,1548 2484,1488"/>
+          <TextEquiv>
+            <Unicode>tum</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>ring of vorgrelukking van deze Ryputheek zal tum</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l14" custom="readingOrder {index:13;}">
+        <Coords points="710,1624 850,1639 880,1625 912,1635 928,1621 948,1633 1047,1624 1127,1666 1175,1623 1251,1645 1274,1624 1299,1640 1317,1622 1352,1620 1395,1627 1445,1671 1480,1658 1481,1539 1435,1561 1391,1533 1327,1586 1102,1584 1045,1563 1011,1581 908,1575 868,1589 782,1574 710,1583 710,1624"/>
+        <Baseline points="722,1612 759,1612 796,1610 833,1610 871,1610 908,1610 945,1610 983,1612 1020,1612 1057,1612 1095,1612 1132,1613 1169,1614 1206,1614 1244,1614 1281,1615 1318,1616 1356,1616 1393,1616 1430,1615 1468,1614"/>
+        <Word id="r8l14_w1">
+          <Coords points="716,1571 716,1631 831,1631 831,1571"/>
+          <TextEquiv>
+            <Unicode>nen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l14_w2">
+          <Coords points="883,1571 883,1631 1071,1631 1071,1571"/>
+          <TextEquiv>
+            <Unicode>worden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l14_w3">
+          <Coords points="1134,1575 1134,1635 1472,1635 1472,1575"/>
+          <TextEquiv>
+            <Unicode>gewonen.</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>nen worden gewonen.</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l15" custom="readingOrder {index:14;}">
+        <Coords points="681,1714 759,1726 816,1703 880,1715 903,1701 1016,1723 1046,1704 1071,1718 1160,1712 1181,1728 1240,1713 1288,1722 1309,1708 1463,1709 1572,1744 1618,1708 1783,1723 1831,1707 1857,1719 1948,1710 2003,1715 2040,1750 2118,1720 2289,1738 2331,1710 2384,1724 2530,1716 2531,1636 2471,1640 2414,1670 2395,1658 2368,1674 2327,1662 2297,1678 2235,1643 2150,1650 2125,1629 2077,1656 2001,1626 1736,1638 1605,1621 1552,1625 1509,1666 1477,1671 1428,1661 1385,1624 1319,1624 1298,1642 1271,1628 1252,1644 1174,1625 1121,1666 1044,1629 782,1641 682,1615 681,1714"/>
+        <Baseline points="692,1694 783,1694 874,1694 965,1696 1057,1696 1148,1696 1239,1698 1331,1698 1422,1700 1513,1700 1605,1702 1696,1702 1787,1703 1878,1704 1970,1704 2061,1704 2152,1704 2244,1704 2335,1704 2426,1702 2518,1702"/>
+        <Word id="r8l15_w1">
+          <Coords points="718,1654 718,1714 777,1714 777,1654"/>
+          <TextEquiv>
+            <Unicode>v</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l15_w2">
+          <Coords points="847,1654 847,1714 958,1714 958,1654"/>
+          <TextEquiv>
+            <Unicode>dat</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l15_w3">
+          <Coords points="1007,1656 1007,1716 1065,1716 1065,1656"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l15_w4">
+          <Coords points="1119,1658 1119,1718 1482,1718 1482,1658"/>
+          <TextEquiv>
+            <Unicode>schuldenan</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l15_w5">
+          <Coords points="1583,1662 1583,1722 1642,1722 1642,1662"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l15_w6">
+          <Coords points="1690,1663 1690,1723 1995,1723 1995,1663"/>
+          <TextEquiv>
+            <Unicode>verbonden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l15_w7">
+          <Coords points="2080,1664 2080,1724 2299,1724 2299,1664"/>
+          <TextEquiv>
+            <Unicode>goederen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l15_w8">
+          <Coords points="2358,1662 2358,1722 2486,1722 2486,1662"/>
+          <TextEquiv>
+            <Unicode>niet</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>v dat de schuldenan de verbonden goederen niet</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l16" custom="readingOrder {index:15;}">
+        <Coords points="695,1819 735,1796 803,1789 986,1816 1030,1837 1078,1798 1110,1816 1136,1800 1165,1814 1195,1794 1243,1810 1369,1799 1422,1843 1555,1791 1718,1792 1743,1806 1807,1793 1967,1812 2011,1792 2038,1808 2116,1801 2134,1818 2212,1804 2247,1809 2272,1832 2299,1823 2345,1837 2384,1814 2524,1799 2524,1749 2419,1762 2360,1716 2275,1761 2213,1731 2167,1760 2089,1744 1997,1764 1929,1722 1857,1763 1775,1754 1745,1735 1686,1758 1507,1748 1402,1761 1347,1726 1246,1732 1216,1718 1122,1734 1088,1709 1038,1706 1012,1724 902,1703 843,1735 790,1714 696,1725 695,1819"/>
+        <Baseline points="708,1782 798,1782 888,1784 978,1784 1068,1784 1159,1784 1249,1784 1339,1784 1429,1786 1519,1786 1610,1786 1700,1786 1790,1786 1880,1788 1970,1788 2061,1788 2151,1790 2241,1790 2331,1792 2421,1792 2512,1794"/>
+        <Word id="r8l16_w1">
+          <Coords points="705,1742 705,1802 767,1802 767,1742"/>
+          <TextEquiv>
+            <Unicode>in</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l16_w2">
+          <Coords points="834,1744 834,1804 1079,1804 1079,1744"/>
+          <TextEquiv>
+            <Unicode>waarde</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l16_w3">
+          <Coords points="1154,1744 1154,1804 1245,1804 1245,1744"/>
+          <TextEquiv>
+            <Unicode>zal</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l16_w4">
+          <Coords points="1308,1745 1308,1805 1532,1805 1532,1745"/>
+          <TextEquiv>
+            <Unicode>mogen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l16_w5">
+          <Coords points="1582,1746 1582,1806 2026,1806 2026,1746"/>
+          <TextEquiv>
+            <Unicode>emiinderen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l16_w6">
+          <Coords points="2080,1749 2080,1809 2138,1809 2138,1749"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l16_w7">
+          <Coords points="2184,1750 2184,1810 2321,1810 2321,1750"/>
+          <TextEquiv>
+            <Unicode>niet</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l16_w8">
+          <Coords points="2383,1752 2383,1812 2479,1812 2479,1752"/>
+          <TextEquiv>
+            <Unicode>von</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>in waarde zal mogen emiinderen en niet von</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l17" custom="readingOrder {index:16;}">
+        <Coords points="712,1899 763,1881 820,1893 856,1925 930,1880 957,1894 987,1876 1077,1877 1243,1929 1289,1897 1377,1877 1436,1891 1480,1880 1516,1899 1546,1879 1638,1882 1663,1896 1743,1880 1791,1908 1807,1895 1878,1904 1988,1880 2032,1887 2075,1918 2103,1897 2160,1893 2217,1914 2311,1908 2334,1920 2394,1888 2419,1902 2458,1887 2495,1894 2495,1818 2435,1859 2358,1858 2298,1823 2252,1828 2225,1848 2181,1825 2154,1834 2118,1801 2021,1844 1893,1799 1861,1826 1842,1813 1799,1840 1751,1835 1725,1848 1689,1843 1636,1797 1588,1794 1489,1841 1448,1834 1386,1852 1304,1835 1263,1805 1212,1793 1157,1818 1109,1818 1080,1799 1029,1837 1001,1828 985,1839 947,1812 862,1802 816,1813 768,1792 740,1819 713,1819 712,1899"/>
+        <Baseline points="724,1864 812,1864 900,1866 988,1868 1076,1868 1164,1868 1252,1870 1340,1870 1428,1870 1516,1872 1604,1872 1692,1872 1780,1872 1868,1874 1956,1874 2044,1875 2132,1876 2220,1878 2308,1878 2396,1880 2484,1882"/>
+        <Word id="r8l17_w1">
+          <Coords points="712,1824 712,1884 948,1884 948,1824"/>
+          <TextEquiv>
+            <Unicode>vonger</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l17_w2">
+          <Coords points="1014,1828 1014,1888 1130,1888 1130,1828"/>
+          <TextEquiv>
+            <Unicode>dan</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l17_w3">
+          <Coords points="1174,1829 1174,1889 1256,1889 1256,1829"/>
+          <TextEquiv>
+            <Unicode>een</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l17_w4">
+          <Coords points="1295,1830 1295,1890 1432,1890 1432,1830"/>
+          <TextEquiv>
+            <Unicode>jaar</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l17_w5">
+          <Coords points="1498,1832 1498,1892 1586,1892 1586,1832"/>
+          <TextEquiv>
+            <Unicode>zal</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l17_w6">
+          <Coords points="1674,1832 1674,1892 1905,1892 1905,1832"/>
+          <TextEquiv>
+            <Unicode>mogen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l17_w7">
+          <Coords points="1954,1835 1954,1895 2262,1895 2262,1835"/>
+          <TextEquiv>
+            <Unicode>verkuren</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l17_w8">
+          <Coords points="2328,1840 2328,1900 2470,1900 2470,1840"/>
+          <TextEquiv>
+            <Unicode>nock</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>vonger dan een jaar zal mogen verkuren nock</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l18" custom="readingOrder {index:17;}">
+        <Coords points="701,1983 735,1960 887,2000 921,1966 969,1986 1038,1964 1152,2013 1198,1967 1276,1988 1308,1970 1347,1977 1398,1961 1439,1986 1489,1968 1547,1980 1563,1966 1631,1987 1707,1969 1755,1983 1860,1972 1879,1984 1897,1972 1961,1977 1977,1993 2037,1987 2064,1969 2115,1978 2133,1967 2174,1985 2206,1965 2296,2020 2332,2013 2383,1970 2431,1980 2461,1968 2479,1987 2536,1969 2537,1907 2500,1902 2408,1934 2296,1908 2232,1935 2161,1896 2117,1928 2044,1925 2010,1943 1930,1888 1872,1908 1790,1885 1721,1905 1696,1884 1657,1905 1549,1877 1524,1902 1423,1881 1380,1897 1329,1883 1244,1928 1150,1905 1130,1923 1077,1918 1056,1934 963,1915 878,1920 864,1933 798,1915 754,1880 701,1905 701,1983"/>
+        <Baseline points="712,1954 802,1956 893,1956 983,1958 1074,1958 1165,1960 1255,1960 1346,1962 1436,1962 1527,1962 1618,1964 1708,1964 1799,1964 1889,1964 1980,1964 2071,1964 2161,1964 2252,1964 2342,1964 2433,1962 2524,1962"/>
+        <Word id="r8l18_w1">
+          <Coords points="712,1918 712,1978 1277,1978 1277,1918"/>
+          <TextEquiv>
+            <Unicode>mimpenningen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l18_w2">
+          <Coords points="1341,1922 1341,1982 1422,1982 1422,1922"/>
+          <TextEquiv>
+            <Unicode>bij</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l18_w3">
+          <Coords points="1465,1924 1465,1984 2008,1984 2008,1924"/>
+          <TextEquiv>
+            <Unicode>voruitbetaling</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l18_w4">
+          <Coords points="2040,1924 2040,1984 2137,1984 2137,1924"/>
+          <TextEquiv>
+            <Unicode>zal</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l18_w5">
+          <Coords points="2180,1924 2180,1984 2400,1984 2400,1924"/>
+          <TextEquiv>
+            <Unicode>mogen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l18_w6">
+          <Coords points="2449,1922 2449,1982 2518,1982 2518,1922"/>
+          <TextEquiv>
+            <Unicode>ont</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>mimpenningen bij voruitbetaling zal mogen ont</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l19" custom="readingOrder {index:18;}">
+        <Coords points="698,2063 746,2081 780,2056 851,2043 915,2067 973,2055 1124,2073 1147,2059 1183,2087 1271,2048 1337,2049 1415,2088 1486,2055 1584,2106 1658,2060 1985,2072 2043,2054 2086,2091 2104,2075 2189,2106 2242,2062 2343,2070 2370,2056 2496,2055 2497,1979 2479,1986 2460,1968 2384,2020 2341,2006 2295,2024 2261,1991 2233,1991 2196,2019 2091,2011 2038,2024 1961,1978 1904,1973 1846,1986 1791,1974 1718,2001 1693,1980 1617,1996 1576,1973 1438,1990 1395,1962 1330,2012 1287,1989 1248,1996 1200,1965 1145,2013 1035,1964 987,2010 961,2016 923,2000 900,2014 865,1988 817,1983 698,1989 698,2063"/>
+        <Baseline points="710,2036 798,2036 887,2037 976,2038 1064,2038 1153,2040 1242,2040 1330,2042 1419,2043 1508,2044 1597,2044 1685,2046 1774,2046 1863,2048 1951,2048 2040,2048 2129,2048 2217,2048 2306,2046 2395,2046 2484,2044"/>
+        <Word id="r8l19_w1">
+          <Coords points="707,1996 707,2056 937,2056 937,1996"/>
+          <TextEquiv>
+            <Unicode>vangen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l19_w2">
+          <Coords points="1001,1999 1001,2059 1218,2059 1218,1999"/>
+          <TextEquiv>
+            <Unicode>zonden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l19_w3">
+          <Coords points="1257,2003 1257,2063 1679,2063 1679,2003"/>
+          <TextEquiv>
+            <Unicode>schriftelijke</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l19_w4">
+          <Coords points="1743,2008 1743,2068 2185,2068 2185,2008"/>
+          <TextEquiv>
+            <Unicode>toestemming</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l19_w5">
+          <Coords points="2237,2006 2237,2066 2345,2066 2345,2006"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l19_w6">
+          <Coords points="2390,2005 2390,2065 2486,2065 2486,2005"/>
+          <TextEquiv>
+            <Unicode>den</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>vangen zonden schriftelijke toestemming van den</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l20" custom="readingOrder {index:19;}">
+        <Coords points="708,2154 805,2156 830,2177 876,2147 951,2156 983,2144 1002,2158 1068,2135 1082,2149 1141,2142 1180,2165 1180,2085 1137,2105 1084,2064 1036,2057 937,2071 896,2060 878,2078 818,2057 786,2078 708,2069 708,2154"/>
+        <Baseline points="720,2122 746,2123 772,2124 799,2124 825,2124 851,2124 878,2124 904,2122 930,2122 957,2122 983,2122 1009,2122 1036,2122 1062,2122 1088,2123 1115,2124 1141,2124 1168,2126"/>
+        <Word id="r8l20_w1">
+          <Coords points="720,2084 720,2144 911,2144 911,2084"/>
+          <TextEquiv>
+            <Unicode>schuld</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l20_w2">
+          <Coords points="929,2082 929,2142 1119,2142 1119,2082"/>
+          <TextEquiv>
+            <Unicode>eischer</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>schuld eischer</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l21" custom="readingOrder {index:20;}">
+        <Coords points="679,2239 734,2224 794,2250 902,2225 952,2249 980,2231 1023,2263 1055,2250 1075,2262 1135,2233 1206,2247 1227,2231 1270,2271 1307,2257 1334,2278 1424,2236 1529,2230 1598,2249 1632,2281 1646,2268 1671,2280 1715,2241 1807,2228 1887,2250 1967,2239 2008,2270 2058,2282 2109,2264 2157,2289 2187,2274 2203,2288 2260,2291 2311,2259 2363,2264 2398,2244 2510,2268 2511,2151 2376,2182 2319,2151 2286,2174 2174,2157 2087,2202 1981,2194 1949,2175 1901,2193 1874,2181 1853,2197 1785,2150 1739,2147 1661,2172 1597,2148 1546,2168 1480,2158 1438,2172 1340,2139 1285,2184 1223,2146 1187,2146 1166,2164 1141,2141 1097,2168 1028,2167 985,2148 930,2164 914,2148 875,2147 829,2177 786,2153 730,2173 680,2170 679,2239"/>
+        <Baseline points="690,2212 780,2212 870,2214 961,2214 1051,2214 1142,2216 1232,2216 1322,2218 1413,2220 1503,2220 1594,2222 1684,2223 1774,2224 1865,2226 1955,2226 2046,2228 2136,2228 2226,2228 2317,2228 2407,2228 2498,2228"/>
+        <Word id="r8l21_w1">
+          <Coords points="707,2172 707,2232 739,2232 739,2172"/>
+          <TextEquiv>
+            <Unicode>„</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l21_w2">
+          <Coords points="778,2173 778,2233 875,2233 875,2173"/>
+          <TextEquiv>
+            <Unicode>dat</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l21_w3">
+          <Coords points="940,2174 940,2234 1011,2234 1011,2174"/>
+          <TextEquiv>
+            <Unicode>bij</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l21_w4">
+          <Coords points="1056,2176 1056,2236 1232,2236 1232,2176"/>
+          <TextEquiv>
+            <Unicode>geheele</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l21_w5">
+          <Coords points="1290,2177 1290,2237 1335,2237 1335,2177"/>
+          <TextEquiv>
+            <Unicode>of</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l21_w6">
+          <Coords points="1373,2181 1373,2241 1769,2241 1769,2181"/>
+          <TextEquiv>
+            <Unicode>gedeeltelijke</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l21_w7">
+          <Coords points="1833,2187 1833,2247 2247,2247 2247,2187"/>
+          <TextEquiv>
+            <Unicode>vervreemding</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l21_w8">
+          <Coords points="2299,2188 2299,2248 2383,2248 2383,2188"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l21_w9">
+          <Coords points="2416,2188 2416,2248 2487,2248 2487,2188"/>
+          <TextEquiv>
+            <Unicode>het</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>„ dat bij geheele of gedeeltelijke vervreemding van het</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l22" custom="readingOrder {index:21;}">
+        <Coords points="705,2315 728,2326 877,2320 900,2334 930,2312 1005,2331 1021,2315 1067,2329 1097,2320 1111,2334 1173,2316 1292,2335 1312,2321 1353,2338 1411,2315 1452,2334 1468,2322 1505,2332 1619,2317 1672,2333 1713,2320 1787,2336 1844,2330 1860,2346 1908,2321 1979,2326 2009,2347 2073,2324 2139,2350 2183,2321 2272,2326 2291,2340 2334,2324 2373,2340 2469,2320 2547,2344 2548,2291 2520,2293 2477,2259 2449,2274 2410,2244 2378,2249 2323,2294 2286,2280 2225,2289 2188,2273 2158,2291 2108,2263 2032,2288 1943,2266 1913,2239 1874,2263 1824,2240 1799,2261 1764,2258 1734,2285 1654,2273 1633,2285 1583,2245 1556,2254 1535,2238 1464,2283 1372,2262 1336,2278 1306,2259 1276,2273 1240,2245 1205,2259 1189,2245 1134,2277 1054,2253 1017,2264 981,2234 955,2245 930,2234 882,2254 855,2231 784,2253 747,2226 706,2225 705,2315"/>
+        <Baseline points="716,2300 807,2302 898,2303 989,2304 1080,2304 1171,2306 1262,2306 1353,2308 1444,2308 1535,2308 1626,2309 1717,2310 1808,2310 1899,2310 1990,2312 2081,2312 2172,2312 2263,2312 2354,2314 2445,2314 2536,2314"/>
+        <Word id="r8l22_w1">
+          <Coords points="713,2263 713,2323 1109,2323 1109,2263"/>
+          <TextEquiv>
+            <Unicode>verbondene,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l22_w2">
+          <Coords points="1136,2266 1136,2326 1391,2326 1391,2266"/>
+          <TextEquiv>
+            <Unicode>wonnen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l22_w3">
+          <Coords points="1468,2268 1468,2328 1555,2328 1555,2268"/>
+          <TextEquiv>
+            <Unicode>het</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l22_w4">
+          <Coords points="1614,2269 1614,2329 1710,2329 1710,2269"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l22_w5">
+          <Coords points="1769,2271 1769,2331 2151,2331 2151,2271"/>
+          <TextEquiv>
+            <Unicode>testemming</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l22_w6">
+          <Coords points="2197,2272 2197,2332 2388,2332 2388,2272"/>
+          <TextEquiv>
+            <Unicode>mocht</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l22_w7">
+          <Coords points="2420,2274 2420,2334 2493,2334 2493,2274"/>
+          <TextEquiv>
+            <Unicode>na</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>verbondene, wonnen het van testemming mocht na</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l23" custom="readingOrder {index:22;}">
+        <Coords points="703,2395 847,2414 890,2406 906,2422 998,2411 1009,2423 1083,2405 1167,2420 1211,2404 1245,2416 1328,2401 1399,2427 1429,2406 1488,2421 1500,2409 1633,2418 1644,2406 1752,2414 1768,2403 1782,2417 1825,2406 1898,2429 1997,2407 2059,2422 2107,2459 2118,2448 2164,2457 2238,2408 2455,2417 2494,2403 2495,2335 2449,2343 2410,2325 2369,2354 2328,2331 2291,2339 2273,2325 2204,2322 2137,2354 2110,2331 2007,2346 1963,2327 1851,2367 1737,2327 1700,2343 1679,2331 1629,2367 1604,2344 1574,2348 1553,2332 1505,2345 1469,2324 1432,2356 1400,2330 1319,2343 1168,2319 1102,2346 1056,2322 1015,2354 888,2362 790,2318 703,2346 703,2395"/>
+        <Baseline points="714,2380 802,2382 891,2384 979,2386 1068,2388 1156,2388 1245,2390 1333,2392 1422,2392 1510,2394 1599,2394 1687,2396 1776,2396 1864,2398 1953,2398 2041,2398 2130,2398 2218,2398 2307,2398 2395,2398 2484,2396"/>
+        <Word id="r8l23_w1">
+          <Coords points="709,2341 709,2401 819,2401 819,2341"/>
+          <TextEquiv>
+            <Unicode>den</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l23_w2">
+          <Coords points="885,2346 885,2406 1160,2406 1160,2346"/>
+          <TextEquiv>
+            <Unicode>randen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l23_w3">
+          <Coords points="1237,2351 1237,2411 1375,2411 1375,2351"/>
+          <TextEquiv>
+            <Unicode>met</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l23_w4">
+          <Coords points="1424,2354 1424,2414 1606,2414 1606,2354"/>
+          <TextEquiv>
+            <Unicode>latere</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l23_w5">
+          <Coords points="1688,2357 1688,2417 2035,2417 2035,2357"/>
+          <TextEquiv>
+            <Unicode>zypotheek</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l23_w6">
+          <Coords points="2096,2358 2096,2418 2168,2418 2168,2358"/>
+          <TextEquiv>
+            <Unicode>af</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l23_w7">
+          <Coords points="2212,2358 2212,2418 2306,2418 2306,2358"/>
+          <TextEquiv>
+            <Unicode>wel</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l23_w8">
+          <Coords points="2355,2357 2355,2417 2465,2417 2465,2357"/>
+          <TextEquiv>
+            <Unicode>met</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>den randen met latere zypotheek af wel met</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l24" custom="readingOrder {index:23;}">
+        <Coords points="703,2519 776,2525 825,2488 898,2517 960,2485 1049,2518 1109,2501 1150,2515 1175,2492 1283,2514 1336,2489 1354,2508 1382,2492 1404,2502 1478,2491 1508,2505 1544,2494 1599,2520 1682,2486 1700,2500 1877,2495 1888,2507 1916,2491 2046,2507 2113,2493 2241,2506 2319,2493 2449,2518 2527,2503 2528,2420 2475,2431 2389,2405 2368,2421 2333,2411 2290,2427 2237,2406 2154,2462 2125,2450 2079,2463 2038,2422 1992,2414 1939,2453 1870,2461 1815,2431 1781,2426 1765,2442 1713,2407 1614,2410 1577,2433 1534,2409 1504,2432 1440,2410 1392,2428 1378,2414 1286,2409 1176,2446 1135,2430 1119,2441 1082,2406 968,2428 908,2423 890,2404 832,2422 805,2408 784,2428 704,2418 703,2519"/>
+        <Baseline points="716,2468 806,2470 896,2472 986,2474 1076,2475 1166,2476 1256,2478 1346,2479 1436,2480 1526,2480 1616,2482 1706,2482 1796,2484 1886,2484 1976,2485 2066,2486 2156,2486 2246,2488 2336,2488 2426,2488 2516,2490"/>
+        <Word id="r8l24_w1">
+          <Coords points="703,2429 703,2489 867,2489 867,2429"/>
+          <TextEquiv>
+            <Unicode>eenig</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l24_w2">
+          <Coords points="913,2434 913,2494 1077,2494 1077,2434"/>
+          <TextEquiv>
+            <Unicode>ander</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l24_w3">
+          <Coords points="1144,2438 1144,2498 1391,2498 1391,2438"/>
+          <TextEquiv>
+            <Unicode>zakelijk</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l24_w4">
+          <Coords points="1468,2440 1468,2500 1627,2500 1627,2440"/>
+          <TextEquiv>
+            <Unicode>recht</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l24_w5">
+          <Coords points="1694,2444 1694,2504 2007,2504 2007,2444"/>
+          <TextEquiv>
+            <Unicode>verwaard,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l24_w6">
+          <Coords points="2028,2446 2028,2506 2121,2506 2121,2446"/>
+          <TextEquiv>
+            <Unicode>zoo</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l24_w7">
+          <Coords points="2167,2447 2167,2507 2238,2507 2238,2447"/>
+          <TextEquiv>
+            <Unicode>het</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l24_w8">
+          <Coords points="2279,2448 2279,2508 2505,2508 2505,2448"/>
+          <TextEquiv>
+            <Unicode>verbonde</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>eenig ander zakelijk recht verwaard, zoo het verbonde</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l25" custom="readingOrder {index:24;}">
+        <Coords points="705,2578 765,2572 824,2587 838,2573 900,2569 934,2586 969,2568 1044,2592 1079,2576 1122,2591 1207,2578 1264,2600 1278,2586 1324,2596 1351,2576 1416,2570 1450,2582 1619,2579 1635,2593 1755,2576 1825,2600 1901,2581 2015,2628 2087,2588 2220,2580 2245,2595 2277,2586 2324,2635 2345,2635 2410,2578 2430,2593 2458,2581 2543,2589 2544,2530 2509,2513 2440,2549 2363,2500 2324,2520 2281,2492 2209,2535 2189,2520 2163,2529 2118,2494 1989,2552 1945,2547 1877,2496 1820,2504 1777,2490 1737,2526 1659,2539 1609,2519 1524,2534 1458,2492 1368,2514 1332,2488 1284,2513 1238,2496 1164,2504 1130,2534 1098,2538 1084,2524 1047,2528 1013,2502 988,2509 965,2486 889,2519 826,2488 784,2524 706,2521 705,2578"/>
+        <Baseline points="716,2554 806,2556 897,2556 988,2556 1079,2558 1170,2558 1260,2560 1351,2562 1442,2562 1533,2564 1624,2566 1714,2566 1805,2568 1896,2570 1987,2571 2078,2572 2168,2574 2259,2574 2350,2576 2441,2576 2532,2576"/>
+        <Word id="r8l25_w1">
+          <Coords points="705,2514 705,2574 765,2574 765,2514"/>
+          <TextEquiv>
+            <Unicode>e</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l25_w2">
+          <Coords points="830,2516 830,2576 895,2576 895,2516"/>
+          <TextEquiv>
+            <Unicode>in</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l25_w3">
+          <Coords points="944,2517 944,2577 1178,2577 1178,2517"/>
+          <TextEquiv>
+            <Unicode>waarde</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l25_w4">
+          <Coords points="1237,2521 1237,2581 1428,2581 1428,2521"/>
+          <TextEquiv>
+            <Unicode>micht</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l25_w5">
+          <Coords points="1503,2526 1503,2586 1950,2586 1950,2526"/>
+          <TextEquiv>
+            <Unicode>verminderen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l25_w6">
+          <Coords points="2025,2531 2025,2591 2063,2591 2063,2531"/>
+          <TextEquiv>
+            <Unicode>of</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l25_w7">
+          <Coords points="2101,2533 2101,2593 2156,2593 2156,2533"/>
+          <TextEquiv>
+            <Unicode>u</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l25_w8">
+          <Coords points="2205,2534 2205,2594 2368,2594 2368,2534"/>
+          <TextEquiv>
+            <Unicode>veslag</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l25_w9">
+          <Coords points="2384,2536 2384,2596 2514,2596 2514,2536"/>
+          <TextEquiv>
+            <Unicode>moeht</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>e in waarde micht verminderen of u veslag moeht</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l26" custom="readingOrder {index:25;}">
+        <Coords points="692,2673 752,2655 777,2671 922,2654 990,2685 1064,2663 1268,2665 1322,2684 1357,2675 1412,2701 1492,2663 1543,2664 1583,2696 1604,2678 1650,2692 1705,2686 1721,2670 1767,2694 1836,2697 1868,2676 1936,2684 1950,2670 2030,2696 2070,2669 2308,2667 2367,2716 2459,2687 2532,2727 2533,2592 2442,2584 2338,2643 2258,2587 2217,2586 2194,2602 2146,2585 2065,2630 1976,2625 1949,2597 1910,2587 1802,2632 1770,2613 1703,2636 1576,2581 1509,2578 1491,2590 1418,2571 1383,2579 1332,2620 1286,2629 1119,2611 1066,2629 1044,2612 1009,2626 957,2579 858,2574 773,2612 739,2597 693,2613 692,2673"/>
+        <Baseline points="704,2642 794,2644 885,2646 976,2648 1067,2650 1158,2652 1248,2654 1339,2654 1430,2656 1521,2658 1612,2658 1702,2660 1793,2660 1884,2660 1975,2662 2066,2662 2156,2662 2247,2662 2338,2662 2429,2662 2520,2662"/>
+        <Word id="r8l26_w1">
+          <Coords points="693,2604 693,2664 905,2664 905,2604"/>
+          <TextEquiv>
+            <Unicode>worden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l26_w2">
+          <Coords points="968,2611 968,2671 1301,2671 1301,2611"/>
+          <TextEquiv>
+            <Unicode>genomen,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l26_w3">
+          <Coords points="1324,2617 1324,2677 1709,2677 1709,2617"/>
+          <TextEquiv>
+            <Unicode>hoofdzoon,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l26_w4">
+          <Coords points="1726,2620 1726,2680 1933,2680 1933,2620"/>
+          <TextEquiv>
+            <Unicode>renten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l26_w5">
+          <Coords points="1973,2622 1973,2682 2048,2682 2048,2622"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l26_w6">
+          <Coords points="2082,2622 2082,2682 2277,2682 2277,2622"/>
+          <TextEquiv>
+            <Unicode>kosten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l26_w7">
+          <Coords points="2346,2622 2346,2682 2472,2682 2472,2622"/>
+          <TextEquiv>
+            <Unicode>dade</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>worden genomen, hoofdzoon, renten en kosten dade</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l27" custom="readingOrder {index:26;}">
+        <Coords points="696,2757 719,2762 735,2748 762,2762 788,2747 836,2761 967,2744 1094,2771 1120,2753 1154,2768 1228,2743 1274,2744 1317,2761 1342,2747 1379,2752 1429,2787 1471,2754 1539,2768 1697,2752 1768,2755 1901,2794 1968,2756 2043,2800 2114,2760 2183,2775 2201,2759 2300,2769 2341,2756 2421,2783 2458,2756 2476,2772 2506,2768 2507,2699 2452,2684 2390,2716 2331,2699 2303,2719 2246,2688 2218,2706 2177,2690 2069,2723 2000,2722 1953,2696 1859,2697 1831,2724 1810,2724 1733,2679 1678,2681 1636,2712 1567,2700 1535,2716 1471,2703 1434,2714 1389,2704 1375,2716 1299,2694 1205,2709 1146,2664 1064,2663 993,2685 926,2659 864,2684 826,2665 796,2678 743,2664 697,2672 696,2757"/>
+        <Baseline points="708,2728 797,2730 886,2730 976,2732 1065,2734 1155,2736 1244,2738 1333,2740 1423,2742 1512,2744 1602,2746 1691,2748 1780,2748 1870,2750 1959,2750 2049,2750 2138,2752 2227,2750 2317,2750 2406,2748 2496,2746"/>
+        <Word id="r8l27_w1">
+          <Coords points="702,2689 702,2749 809,2749 809,2689"/>
+          <TextEquiv>
+            <Unicode>lijk</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l27_w2">
+          <Coords points="884,2693 884,2753 1240,2753 1240,2693"/>
+          <TextEquiv>
+            <Unicode>vorderbaar</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l27_w3">
+          <Coords points="1320,2700 1320,2760 1390,2760 1390,2700"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l27_w4">
+          <Coords points="1444,2706 1444,2766 1826,2766 1826,2706"/>
+          <TextEquiv>
+            <Unicode>opeischlaar</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l27_w5">
+          <Coords points="1881,2710 1881,2770 2058,2770 2058,2710"/>
+          <TextEquiv>
+            <Unicode>zijn,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l27_w6">
+          <Coords points="2085,2711 2085,2771 2230,2771 2230,2711"/>
+          <TextEquiv>
+            <Unicode>gelyk</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l27_w7">
+          <Coords points="2306,2708 2306,2768 2462,2768 2462,2708"/>
+          <TextEquiv>
+            <Unicode>mede</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>lijk vorderbaar en opeischlaar zijn, gelyk mede</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l28" custom="readingOrder {index:27;}">
+        <Coords points="720,2844 926,2833 988,2866 1135,2827 1183,2855 1282,2831 1325,2848 1472,2838 1510,2862 1570,2835 1705,2851 1824,2843 1859,2857 1944,2842 2026,2850 2053,2876 2154,2882 2177,2869 2248,2897 2278,2881 2351,2892 2411,2863 2479,2873 2481,2786 2451,2767 2407,2787 2389,2771 2357,2777 2318,2760 2267,2792 2206,2761 2174,2786 2105,2764 2043,2803 1993,2765 1924,2794 1860,2782 1827,2791 1800,2765 1777,2765 1736,2766 1699,2798 1633,2783 1612,2801 1585,2790 1454,2802 1379,2752 1310,2756 1280,2774 1228,2743 1129,2786 1097,2785 1058,2755 1030,2759 968,2800 911,2790 863,2755 812,2797 721,2796 720,2844"/>
+        <Baseline points="732,2818 818,2818 905,2818 992,2820 1079,2820 1166,2820 1252,2822 1339,2822 1426,2824 1513,2826 1600,2828 1686,2830 1773,2830 1860,2832 1947,2834 2034,2834 2120,2836 2207,2836 2294,2836 2381,2838 2468,2836"/>
+        <Word id="r8l28_w1">
+          <Coords points="726,2778 726,2838 941,2838 941,2778"/>
+          <TextEquiv>
+            <Unicode>onder</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l28_w2">
+          <Coords points="991,2780 991,2840 1052,2840 1052,2780"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l28_w3">
+          <Coords points="1102,2782 1102,2842 1466,2842 1466,2782"/>
+          <TextEquiv>
+            <Unicode>schuldenaa</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l28_w4">
+          <Coords points="1583,2789 1583,2849 1754,2849 1754,2789"/>
+          <TextEquiv>
+            <Unicode>wordt</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l28_w5">
+          <Coords points="1815,2794 1815,2854 2097,2854 2097,2794"/>
+          <TextEquiv>
+            <Unicode>verklaard</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l28_w6">
+          <Coords points="2141,2796 2141,2856 2180,2856 2180,2796"/>
+          <TextEquiv>
+            <Unicode>te</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l28_w7">
+          <Coords points="2224,2796 2224,2856 2318,2856 2318,2796"/>
+          <TextEquiv>
+            <Unicode>zijn</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l28_w8">
+          <Coords points="2368,2797 2368,2857 2428,2857 2428,2797"/>
+          <TextEquiv>
+            <Unicode>in</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>onder de schuldenaa wordt verklaard te zijn in</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l29" custom="readingOrder {index:28;}">
+        <Coords points="699,2929 763,2941 789,2919 811,2942 853,2923 926,2940 963,2922 1035,2965 1091,2925 1127,2942 1160,2926 1203,2939 1224,2921 1258,2935 1291,2915 1315,2932 1400,2942 1435,2918 1494,2933 1533,2920 1605,2981 1675,2927 1732,2949 1765,2924 1808,2946 1872,2922 1954,2978 2104,2938 2124,2954 2174,2946 2186,2958 2209,2944 2328,2961 2392,2943 2413,2962 2456,2945 2506,2962 2527,2960 2529,2871 2495,2858 2467,2874 2378,2872 2347,2892 2288,2882 2267,2897 2173,2903 2141,2877 2100,2876 2070,2901 2024,2895 1993,2862 1938,2852 1889,2886 1768,2867 1729,2876 1677,2840 1612,2864 1551,2847 1468,2886 1417,2876 1375,2836 1289,2860 1251,2839 1182,2856 1134,2827 1035,2880 950,2844 914,2857 891,2838 739,2852 701,2837 699,2929"/>
+        <Baseline points="712,2902 802,2904 892,2904 982,2905 1072,2906 1163,2908 1253,2908 1343,2910 1433,2912 1523,2914 1614,2916 1704,2918 1794,2920 1884,2922 1974,2924 2065,2926 2155,2928 2245,2930 2335,2932 2425,2934 2516,2936"/>
+        <Word id="r8l29_w1">
+          <Coords points="707,2863 707,2923 848,2923 848,2863"/>
+          <TextEquiv>
+            <Unicode>staad</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l29_w2">
+          <Coords points="904,2864 904,2924 996,2924 996,2864"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l29_w3">
+          <Coords points="1070,2869 1070,2929 1570,2929 1570,2869"/>
+          <TextEquiv>
+            <Unicode>Juillissement,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l29_w4">
+          <Coords points="1594,2876 1594,2936 1656,2936 1656,2876"/>
+          <TextEquiv>
+            <Unicode>bij</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l29_w5">
+          <Coords points="1712,2882 1712,2942 2057,2942 2057,2882"/>
+          <TextEquiv>
+            <Unicode>vrijwilligen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l29_w6">
+          <Coords points="2088,2886 2088,2946 2130,2946 2130,2886"/>
+          <TextEquiv>
+            <Unicode>af</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l29_w7">
+          <Coords points="2186,2892 2186,2952 2519,2952 2519,2892"/>
+          <TextEquiv>
+            <Unicode>gerecktelij-</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>staad van Juillissement, bij vrijwilligen af gerecktelij-</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l30" custom="readingOrder {index:29;}">
+        <Coords points="712,3027 891,3006 962,3030 1022,3010 1120,3048 1184,3015 1345,3010 1415,3064 1436,3064 1519,3012 1611,3025 1666,3012 1698,3031 1732,3017 1755,3036 1785,3016 1899,3013 1954,3039 2023,3014 2085,3031 2124,3018 2215,3047 2266,3022 2280,3036 2305,3029 2355,3064 2399,3024 2495,3023 2496,2956 2457,2944 2416,2967 2381,2946 2319,2984 2281,2944 2255,2955 2205,2946 2180,2961 2102,2940 2047,2978 2001,2959 1973,2982 1891,2953 1836,2966 1770,2926 1710,2953 1674,2930 1611,2984 1534,2925 1499,2953 1440,2920 1368,2962 1291,2918 1257,2936 1232,2919 1181,2948 1089,2927 1043,2970 982,2925 957,2923 936,2943 901,2933 853,2967 792,2923 713,2956 712,3027"/>
+        <Baseline points="724,2992 812,2994 900,2996 988,2998 1076,3000 1164,3000 1252,3002 1340,3004 1428,3004 1516,3006 1604,3006 1692,3008 1780,3008 1868,3010 1956,3010 2044,3012 2132,3012 2220,3014 2308,3014 2396,3016 2484,3016"/>
+        <Word id="r8l30_w1">
+          <Coords points="723,2953 723,3013 838,3013 838,2953"/>
+          <TextEquiv>
+            <Unicode>ten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l30_w2">
+          <Coords points="902,2960 902,3020 1369,3020 1369,2960"/>
+          <TextEquiv>
+            <Unicode>boedelafeland</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l30_w3">
+          <Coords points="1441,2964 1441,3024 1492,3024 1492,2964"/>
+          <TextEquiv>
+            <Unicode>of</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l30_w4">
+          <Coords points="1535,2967 1535,3027 1786,3027 1786,2967"/>
+          <TextEquiv>
+            <Unicode>nalatig</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l30_w5">
+          <Coords points="1829,2969 1829,3029 1879,3029 1879,2969"/>
+          <TextEquiv>
+            <Unicode>is</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l30_w6">
+          <Coords points="1929,2970 1929,3030 1995,3030 1995,2970"/>
+          <TextEquiv>
+            <Unicode>in</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l30_w7">
+          <Coords points="2037,2972 2037,3032 2102,3032 2102,2972"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l30_w8">
+          <Coords points="2152,2974 2152,3034 2461,3034 2461,2974"/>
+          <TextEquiv>
+            <Unicode>behoorlyke</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>ten boedelafeland of nalatig is in de behoorlyke</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l31" custom="readingOrder {index:30;}">
+        <Coords points="707,3098 762,3106 778,3095 806,3109 898,3095 920,3109 934,3095 952,3114 994,3099 1032,3129 1093,3089 1179,3111 1308,3095 1326,3114 1420,3125 1468,3094 1596,3117 1649,3099 1669,3118 1748,3099 1814,3119 1850,3149 1981,3103 2015,3122 2041,3104 2126,3118 2268,3109 2290,3130 2332,3110 2425,3158 2473,3145 2476,3021 2446,3020 2406,3045 2260,3024 2232,3044 2200,3039 2170,3054 2121,3017 2003,3056 1880,3021 1827,3048 1792,3047 1726,3018 1673,3054 1634,3051 1580,3016 1513,3014 1430,3066 1344,3009 1295,3033 1268,3017 1213,3018 1180,3047 1084,3057 886,3005 761,3032 709,3025 707,3098"/>
+        <Baseline points="720,3072 807,3074 894,3076 981,3078 1068,3080 1155,3082 1242,3084 1329,3084 1416,3086 1503,3087 1591,3088 1678,3090 1765,3090 1852,3092 1939,3094 2026,3096 2113,3098 2200,3100 2287,3102 2374,3106 2462,3110"/>
+        <Word id="r8l31_w1">
+          <Coords points="709,3035 709,3095 1073,3095 1073,3035"/>
+          <TextEquiv>
+            <Unicode>voldoening</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l31_w2">
+          <Coords points="1128,3042 1128,3102 1226,3102 1226,3042"/>
+          <TextEquiv>
+            <Unicode>om</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l31_w3">
+          <Coords points="1286,3046 1286,3106 1572,3106 1572,3046"/>
+          <TextEquiv>
+            <Unicode>kapitaal</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l31_w4">
+          <Coords points="1651,3049 1651,3109 1693,3109 1693,3049"/>
+          <TextEquiv>
+            <Unicode>of</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l31_w5">
+          <Coords points="1724,3051 1724,3111 1894,3111 1894,3051"/>
+          <TextEquiv>
+            <Unicode>rente</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l31_w6">
+          <Coords points="1967,3055 1967,3115 2040,3115 2040,3055"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l31_w7">
+          <Coords points="2077,3060 2077,3120 2363,3120 2363,3060"/>
+          <TextEquiv>
+            <Unicode>eindelijk</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l31_w8">
+          <Coords points="2424,3069 2424,3129 2478,3129 2478,3069"/>
+          <TextEquiv>
+            <Unicode>bij</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>voldoening om kapitaal of rente en eindelijk bij</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l32" custom="readingOrder {index:31;}">
+        <Coords points="712,3198 888,3192 915,3213 939,3193 1008,3180 1090,3202 1280,3180 1292,3192 1367,3186 1410,3212 1452,3183 1580,3183 1672,3208 1718,3186 1786,3196 1823,3183 1883,3202 1954,3194 1995,3218 2055,3198 2086,3210 2160,3198 2219,3247 2272,3195 2510,3209 2511,3147 2452,3143 2420,3157 2333,3109 2292,3127 2278,3118 2234,3156 2170,3139 2154,3154 2090,3142 2021,3159 1932,3111 1895,3145 1849,3149 1790,3107 1737,3126 1712,3112 1673,3121 1653,3100 1572,3140 1533,3137 1481,3094 1426,3126 1375,3113 1283,3141 1231,3101 1181,3112 1099,3090 1038,3128 1018,3111 976,3131 956,3117 924,3126 890,3098 837,3131 713,3124 712,3198"/>
+        <Baseline points="724,3158 812,3160 901,3162 990,3164 1079,3166 1168,3168 1256,3170 1345,3171 1434,3172 1523,3174 1612,3176 1700,3177 1789,3178 1878,3180 1967,3182 2056,3182 2144,3184 2233,3186 2322,3188 2411,3188 2500,3190"/>
+        <Word id="r8l32_w1">
+          <Coords points="713,3119 713,3179 858,3179 858,3119"/>
+          <TextEquiv>
+            <Unicode>met</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l32_w2">
+          <Coords points="920,3126 920,3186 1313,3186 1313,3126"/>
+          <TextEquiv>
+            <Unicode>nakoming</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l32_w3">
+          <Coords points="1369,3131 1369,3191 1420,3191 1420,3131"/>
+          <TextEquiv>
+            <Unicode>of</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l32_w4">
+          <Coords points="1464,3136 1464,3196 1846,3196 1846,3136"/>
+          <TextEquiv>
+            <Unicode>overtreding</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l32_w5">
+          <Coords points="1891,3141 1891,3201 2003,3201 2003,3141"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l32_w6">
+          <Coords points="2065,3143 2065,3203 2166,3203 2166,3143"/>
+          <TextEquiv>
+            <Unicode>een</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l32_w7">
+          <Coords points="2217,3146 2217,3206 2273,3206 2273,3146"/>
+          <TextEquiv>
+            <Unicode>af</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l32_w8">
+          <Coords points="2306,3148 2306,3208 2463,3208 2463,3148"/>
+          <TextEquiv>
+            <Unicode>meer</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>met nakoming of overtreding van een af meer</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l33" custom="readingOrder {index:32;}">
+        <Coords points="689,3273 755,3297 804,3270 973,3280 1058,3261 1081,3277 1163,3274 1232,3295 1276,3278 1436,3284 1466,3273 1553,3289 1615,3289 1642,3274 1754,3289 1791,3274 1809,3288 1846,3277 1949,3297 2046,3282 2123,3292 2153,3277 2185,3296 2238,3280 2423,3297 2511,3280 2512,3211 2461,3215 2448,3203 2385,3248 2354,3220 2267,3201 2216,3248 2154,3199 2088,3212 2061,3198 2019,3234 1952,3237 1822,3185 1790,3196 1715,3188 1687,3213 1612,3189 1591,3209 1453,3191 1389,3233 1334,3191 1282,3179 1228,3226 1196,3212 1075,3231 1047,3215 1001,3228 972,3213 820,3227 761,3192 727,3217 690,3218 689,3273"/>
+        <Baseline points="700,3248 790,3249 880,3250 970,3252 1060,3254 1150,3254 1240,3256 1330,3258 1420,3258 1510,3260 1600,3262 1690,3262 1780,3264 1870,3265 1960,3266 2050,3268 2140,3270 2230,3270 2320,3272 2410,3274 2500,3274"/>
+        <Word id="r8l33_w1">
+          <Coords points="704,3208 704,3268 807,3268 807,3208"/>
+          <TextEquiv>
+            <Unicode>der</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l33_w2">
+          <Coords points="880,3212 880,3272 1128,3272 1128,3212"/>
+          <TextEquiv>
+            <Unicode>overge</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l33_w3">
+          <Coords points="1227,3217 1227,3277 1351,3277 1351,3217"/>
+          <TextEquiv>
+            <Unicode>doe</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l33_w4">
+          <Coords points="1428,3219 1428,3279 1532,3279 1532,3219"/>
+          <TextEquiv>
+            <Unicode>den</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l33_w5">
+          <Coords points="1594,3224 1594,3284 2013,3284 2013,3224"/>
+          <TextEquiv>
+            <Unicode>schuldenaar</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l33_w6">
+          <Coords points="2091,3229 2091,3289 2179,3289 2179,3229"/>
+          <TextEquiv>
+            <Unicode>bij</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l33_w7">
+          <Coords points="2221,3231 2221,3291 2334,3291 2334,3231"/>
+          <TextEquiv>
+            <Unicode>deze</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l33_w8">
+          <Coords points="2376,3234 2376,3294 2489,3294 2489,3234"/>
+          <TextEquiv>
+            <Unicode>akte</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>der overge doe den schuldenaar bij deze akte</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l34" custom="readingOrder {index:33;}">
+        <Coords points="696,3343 760,3361 818,3353 836,3369 882,3357 916,3374 999,3355 1065,3377 1141,3354 1186,3378 1244,3356 1363,3378 1402,3358 1450,3373 1475,3362 1541,3407 1596,3395 1631,3361 1656,3376 1684,3365 1686,3285 1642,3275 1575,3319 1472,3298 1450,3279 1397,3301 1294,3277 1222,3312 1093,3325 1078,3311 1013,3323 904,3302 880,3315 826,3280 748,3298 698,3276 696,3343"/>
+        <Baseline points="708,3328 756,3331 804,3333 852,3336 900,3338 949,3340 997,3341 1045,3342 1093,3344 1141,3346 1190,3346 1238,3347 1286,3348 1334,3349 1382,3350 1431,3350 1479,3352 1527,3352 1575,3352 1623,3354 1672,3354"/>
+        <Word id="r8l34_w1">
+          <Coords points="699,3297 699,3357 1066,3357 1066,3297"/>
+          <TextEquiv>
+            <Unicode>aangegane</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l34_w2">
+          <Coords points="1149,3310 1149,3370 1653,3370 1653,3310"/>
+          <TextEquiv>
+            <Unicode>verbiatenissen</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>aangegane verbiatenissen</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l35" custom="readingOrder {index:34;}">
+        <Coords points="683,3456 754,3446 786,3465 857,3454 880,3466 1013,3440 1054,3464 1084,3441 1162,3468 1242,3444 1432,3460 1456,3442 1485,3454 1522,3443 1554,3467 1586,3469 1660,3443 1781,3447 1833,3475 1987,3445 2026,3464 2095,3456 2124,3486 2220,3497 2278,3454 2347,3464 2393,3451 2411,3465 2516,3455 2517,3394 2474,3391 2425,3420 2343,3373 2240,3371 2203,3384 2085,3371 2050,3387 2025,3377 1995,3404 1969,3404 1938,3378 1873,3407 1834,3407 1777,3376 1750,3385 1732,3371 1692,3386 1619,3371 1594,3396 1520,3409 1461,3392 1353,3404 1323,3395 1287,3357 1214,3361 1168,3381 1138,3360 1106,3364 1076,3391 1012,3358 946,3371 916,3352 840,3372 806,3353 790,3366 684,3367 683,3456"/>
+        <Baseline points="696,3422 786,3422 876,3422 967,3424 1057,3424 1148,3426 1238,3428 1328,3428 1419,3430 1509,3432 1600,3434 1690,3435 1780,3436 1871,3438 1961,3439 2052,3440 2142,3442 2232,3442 2323,3444 2413,3444 2504,3444"/>
+        <Word id="r8l35_w1">
+          <Coords points="693,3382 693,3442 729,3442 729,3382"/>
+          <TextEquiv>
+            <Unicode>s</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l35_w2">
+          <Coords points="786,3382 786,3442 874,3442 874,3382"/>
+          <TextEquiv>
+            <Unicode>dat</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l35_w3">
+          <Coords points="921,3383 921,3443 967,3443 967,3383"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l35_w4">
+          <Coords points="1029,3387 1029,3447 1381,3447 1381,3387"/>
+          <TextEquiv>
+            <Unicode>schulderen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l35_w5">
+          <Coords points="1464,3394 1464,3454 1759,3454 1759,3394"/>
+          <TextEquiv>
+            <Unicode>verschikt</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l35_w6">
+          <Coords points="1822,3397 1822,3457 1915,3457 1915,3397"/>
+          <TextEquiv>
+            <Unicode>zal</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l35_w7">
+          <Coords points="1956,3399 1956,3459 2065,3459 2065,3399"/>
+          <TextEquiv>
+            <Unicode>zijn</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l35_w8">
+          <Coords points="2111,3402 2111,3462 2194,3462 2194,3402"/>
+          <TextEquiv>
+            <Unicode>sel</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l35_w9">
+          <Coords points="2246,3404 2246,3464 2479,3464 2479,3404"/>
+          <TextEquiv>
+            <Unicode>gebonwe</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>s dat de schulderen verschikt zal zijn sel gebonwe</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l36" custom="readingOrder {index:35;}">
+        <Coords points="700,3519 752,3549 778,3531 858,3544 1020,3532 1046,3544 1087,3530 1105,3547 1179,3529 1192,3543 1344,3534 1385,3552 1476,3537 1492,3554 1518,3543 1568,3555 1646,3530 1676,3547 1722,3520 1776,3553 1879,3556 1932,3534 1985,3534 2063,3577 2099,3570 2143,3585 2228,3542 2280,3582 2333,3543 2473,3531 2474,3497 2375,3500 2298,3456 2212,3498 2132,3495 2098,3460 2025,3464 1988,3445 1959,3459 1938,3451 1873,3501 1720,3483 1670,3446 1638,3448 1601,3479 1526,3444 1498,3446 1406,3489 1340,3444 1271,3471 1232,3450 1154,3467 1079,3443 1023,3488 916,3473 849,3486 829,3465 785,3465 753,3446 721,3478 700,3478 700,3519"/>
+        <Baseline points="712,3510 799,3510 887,3510 974,3512 1062,3512 1149,3513 1237,3514 1324,3514 1412,3516 1499,3518 1587,3518 1674,3520 1762,3520 1849,3522 1937,3522 2024,3524 2112,3526 2199,3526 2287,3528 2374,3528 2462,3530"/>
+        <Word id="r8l36_w1">
+          <Coords points="701,3470 701,3530 770,3530 770,3470"/>
+          <TextEquiv>
+            <Unicode>bij</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l36_w2">
+          <Coords points="804,3470 804,3530 919,3530 919,3470"/>
+          <TextEquiv>
+            <Unicode>eene</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l36_w3">
+          <Coords points="971,3472 971,3532 1189,3532 1189,3472"/>
+          <TextEquiv>
+            <Unicode>orliede</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l36_w4">
+          <Coords points="1264,3478 1264,3538 1741,3538 1741,3478"/>
+          <TextEquiv>
+            <Unicode>trandwaarbrg</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l36_w5">
+          <Coords points="1758,3482 1758,3542 2195,3542 2195,3482"/>
+          <TextEquiv>
+            <Unicode>martnkappij</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l36_w6">
+          <Coords points="2241,3488 2241,3548 2390,3548 2390,3488"/>
+          <TextEquiv>
+            <Unicode>tegen</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>bij eene orliede trandwaarbrg martnkappij tegen</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l37" custom="readingOrder {index:36;}">
+        <Coords points="688,3625 730,3612 755,3624 773,3610 805,3629 821,3618 860,3628 922,3599 988,3634 1060,3601 1126,3644 1190,3615 1245,3634 1346,3610 1366,3629 1406,3618 1430,3637 1493,3613 1554,3623 1582,3610 1676,3630 1752,3617 1781,3638 1850,3616 1898,3640 1933,3622 1985,3635 2141,3623 2244,3639 2288,3626 2333,3652 2356,3629 2384,3643 2434,3633 2436,3539 2410,3550 2358,3537 2277,3587 2227,3545 2188,3583 2130,3589 2023,3569 1933,3583 1902,3555 1848,3580 1803,3572 1723,3520 1583,3575 1530,3549 1370,3554 1345,3537 1308,3557 1237,3535 1127,3575 1084,3531 1049,3548 1029,3532 946,3528 907,3551 786,3530 689,3556 688,3625"/>
+        <Baseline points="700,3596 786,3594 872,3594 958,3594 1044,3594 1131,3594 1217,3594 1303,3596 1389,3596 1475,3598 1562,3600 1648,3602 1734,3604 1820,3606 1906,3608 1993,3610 2079,3612 2165,3614 2251,3616 2337,3618 2424,3618"/>
+        <Word id="r8l37_w1">
+          <Coords points="698,3554 698,3614 1091,3614 1091,3554"/>
+          <TextEquiv>
+            <Unicode>monenkede</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l37_w2">
+          <Coords points="1162,3554 1162,3614 1197,3614 1197,3554"/>
+          <TextEquiv>
+            <Unicode>te</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l37_w3">
+          <Coords points="1268,3556 1268,3616 1404,3616 1404,3556"/>
+          <TextEquiv>
+            <Unicode>doen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l37_w4">
+          <Coords points="1470,3561 1470,3621 1804,3621 1804,3561"/>
+          <TextEquiv>
+            <Unicode>gerrekeren</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l37_w5">
+          <Coords points="1869,3567 1869,3627 1939,3627 1939,3567"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l37_w6">
+          <Coords points="1985,3573 1985,3633 2288,3633 2288,3573"/>
+          <TextEquiv>
+            <Unicode>verzekend</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l37_w7">
+          <Coords points="2354,3578 2354,3638 2399,3638 2399,3578"/>
+          <TextEquiv>
+            <Unicode>te</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>monenkede te doen gerrekeren en verzekend te</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l38" custom="readingOrder {index:37;}">
+        <Coords points="704,3693 766,3685 795,3711 852,3705 870,3723 903,3706 981,3719 1034,3703 1168,3743 1219,3702 1262,3717 1302,3699 1347,3746 1453,3702 1480,3716 1627,3707 1647,3721 1666,3706 1746,3719 1852,3709 1874,3723 2166,3708 2214,3715 2270,3760 2328,3738 2360,3750 2383,3737 2442,3747 2488,3734 2490,3640 2418,3666 2398,3655 2372,3677 2267,3657 2233,3629 2201,3646 2119,3624 2070,3642 2018,3625 1915,3625 1892,3648 1820,3663 1725,3624 1678,3660 1648,3664 1511,3662 1454,3635 1401,3646 1296,3619 1269,3634 1212,3620 1117,3643 1072,3619 998,3655 923,3601 826,3649 772,3609 751,3625 705,3624 704,3693"/>
+        <Baseline points="716,3678 804,3678 892,3680 980,3682 1068,3682 1156,3684 1244,3686 1332,3688 1420,3688 1508,3690 1597,3692 1685,3694 1773,3696 1861,3698 1949,3699 2037,3700 2125,3702 2213,3704 2301,3705 2389,3706 2478,3708"/>
+        <Word id="r8l38_w1">
+          <Coords points="705,3638 705,3698 928,3698 928,3638"/>
+          <TextEquiv>
+            <Unicode>houden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l38_w2">
+          <Coords points="1001,3642 1001,3702 1113,3702 1113,3642"/>
+          <TextEquiv>
+            <Unicode>ten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l38_w3">
+          <Coords points="1152,3647 1152,3707 1453,3707 1453,3647"/>
+          <TextEquiv>
+            <Unicode>genoegen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l38_w4">
+          <Coords points="1509,3651 1509,3711 1615,3711 1615,3651"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l38_w5">
+          <Coords points="1666,3654 1666,3714 1772,3714 1772,3654"/>
+          <TextEquiv>
+            <Unicode>den</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l38_w6">
+          <Coords points="1839,3660 1839,3720 2319,3720 2319,3660"/>
+          <TextEquiv>
+            <Unicode>schuldeischer,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l38_w7">
+          <Coords points="2336,3665 2336,3725 2437,3725 2437,3665"/>
+          <TextEquiv>
+            <Unicode>zul</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>houden ten genoegen van den schuldeischer, zul</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r8l39" custom="readingOrder {index:38;}">
+        <Coords points="708,3797 882,3788 1006,3820 1082,3787 1162,3788 1203,3818 1230,3800 1315,3809 1345,3786 1457,3795 1540,3782 1565,3799 1586,3788 1668,3803 1707,3790 1794,3795 1862,3836 1895,3813 1936,3823 1964,3800 2007,3801 2039,3820 2085,3798 2158,3831 2229,3811 2261,3833 2319,3795 2339,3811 2395,3791 2456,3820 2491,3804 2492,3749 2455,3760 2434,3739 2384,3736 2359,3752 2306,3744 2267,3759 2235,3734 2191,3747 2093,3720 2015,3758 1965,3711 1790,3740 1713,3709 1667,3729 1635,3710 1603,3715 1580,3733 1525,3706 1396,3748 1284,3749 1220,3702 1172,3740 1112,3748 1037,3731 1019,3712 952,3741 897,3738 851,3705 794,3709 749,3685 710,3691 708,3797"/>
+        <Baseline points="720,3758 808,3762 896,3764 984,3766 1072,3768 1160,3770 1248,3772 1336,3774 1424,3774 1512,3776 1600,3778 1688,3778 1776,3780 1864,3781 1952,3782 2040,3783 2128,3784 2216,3786 2304,3786 2392,3787 2480,3788"/>
+        <Word id="r8l39_w1">
+          <Coords points="721,3721 721,3781 883,3781 883,3721"/>
+          <TextEquiv>
+            <Unicode>rende</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l39_w2">
+          <Coords points="945,3727 945,3787 1198,3787 1198,3727"/>
+          <TextEquiv>
+            <Unicode>ingeval</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l39_w3">
+          <Coords points="1270,3733 1270,3793 1370,3793 1370,3733"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l39_w4">
+          <Coords points="1423,3736 1423,3796 1656,3796 1656,3736"/>
+          <TextEquiv>
+            <Unicode>schaden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l39_w5">
+          <Coords points="1695,3738 1695,3798 1747,3798 1747,3738"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r8l39_w6">
+          <Coords points="1799,3744 1799,3804 2477,3804 2477,3744"/>
+          <TextEquiv>
+            <Unicode>Asmrontiepenningen</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>rende ingeval van schaden de Asmrontiepenningen</Unicode>
+        </TextEquiv>
+      </TextLine>
+    </TextRegion>
+    <TextRegion orientation="0.0" id="r9" custom="readingOrder {index:8;}">
+      <Coords points="3068,241 3068,3173 4886,3173 4886,241"/>
+      <TextLine id="r9l1" custom="readingOrder {index:0;}">
+        <Coords points="3069,301 3168,290 3351,311 3425,291 3495,317 3525,301 3537,313 3592,302 3608,318 3635,300 3748,297 3796,311 3892,296 3924,320 3952,302 4057,298 4077,315 4295,303 4364,325 4428,305 4488,308 4508,324 4568,304 4611,330 4703,303 4739,327 4790,307 4870,330 4871,248 4795,261 4766,247 4731,262 4665,225 4626,234 4596,208 4571,226 4527,228 4495,257 4454,257 4427,229 4392,247 4315,214 4266,250 4225,245 4177,263 4069,207 3959,261 3916,237 3858,250 3804,211 3739,242 3666,198 3620,209 3549,196 3526,214 3508,200 3426,197 3343,237 3311,216 3244,250 3177,261 3136,240 3070,253 3069,301"/>
+        <Baseline points="3080,284 3169,284 3258,284 3347,284 3436,284 3525,286 3614,286 3703,287 3792,288 3881,290 3970,290 4059,292 4148,294 4237,295 4326,296 4415,298 4504,298 4593,299 4682,300 4771,300 4860,300"/>
+        <Word id="r9l1_w1">
+          <Coords points="3074,244 3074,304 3185,304 3185,244"/>
+          <TextEquiv>
+            <Unicode>aan</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l1_w2">
+          <Coords points="3233,244 3233,304 3329,304 3329,244"/>
+          <TextEquiv>
+            <Unicode>den</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l1_w3">
+          <Coords points="3403,245 3403,305 3589,305 3589,245"/>
+          <TextEquiv>
+            <Unicode>schuld</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l1_w4">
+          <Coords points="3621,247 3621,307 3818,307 3818,247"/>
+          <TextEquiv>
+            <Unicode>eischen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l1_w5">
+          <Coords points="3897,250 3897,310 4115,310 4115,250"/>
+          <TextEquiv>
+            <Unicode>worden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l1_w6">
+          <Coords points="4168,256 4168,316 4508,316 4508,256"/>
+          <TextEquiv>
+            <Unicode>uitbetaald</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l1_w7">
+          <Coords points="4582,259 4582,319 4662,319 4662,259"/>
+          <TextEquiv>
+            <Unicode>ten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l1_w8">
+          <Coords points="4705,260 4705,320 4853,320 4853,260"/>
+          <TextEquiv>
+            <Unicode>einde</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>aan den schuld eischen worden uitbetaald ten einde</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l2" custom="readingOrder {index:1;}">
+        <Coords points="3066,390 3119,377 3146,389 3158,377 3307,391 3412,382 3458,397 3513,381 3634,399 3655,387 3903,399 4056,389 4074,401 4129,390 4198,414 4267,394 4313,406 4434,393 4505,408 4528,394 4640,446 4707,394 4856,393 4856,329 4820,322 4797,342 4746,349 4710,325 4678,339 4650,322 4598,322 4579,340 4527,326 4494,348 4435,338 4402,361 4250,307 4201,334 4151,303 4073,319 4039,302 3970,301 3940,331 3878,316 3795,350 3733,352 3686,337 3649,346 3635,332 3578,343 3553,327 3532,340 3454,330 3420,341 3365,304 3338,304 3291,347 3262,347 3202,341 3147,306 3115,324 3067,317 3066,390"/>
+        <Baseline points="3078,372 3166,370 3254,370 3342,372 3431,372 3519,374 3607,374 3696,376 3784,378 3872,380 3961,380 4049,382 4137,384 4225,384 4314,386 4402,386 4490,386 4579,386 4667,386 4755,384 4844,382"/>
+        <Word id="r9l2_w1">
+          <Coords points="3067,330 3067,390 3343,390 3343,330"/>
+          <TextEquiv>
+            <Unicode>daarndt</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l2_w2">
+          <Coords points="3411,333 3411,393 3541,393 3541,333"/>
+          <TextEquiv>
+            <Unicode>voor</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l2_w3">
+          <Coords points="3586,339 3586,399 4118,399 4118,339"/>
+          <TextEquiv>
+            <Unicode>zoorentrekkende</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l2_w4">
+          <Coords points="4203,344 4203,404 4282,404 4282,344"/>
+          <TextEquiv>
+            <Unicode>tet</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l2_w5">
+          <Coords points="4339,346 4339,406 4621,406 4621,346"/>
+          <TextEquiv>
+            <Unicode>veschuld</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l2_w6">
+          <Coords points="4649,345 4649,405 4751,405 4751,345"/>
+          <TextEquiv>
+            <Unicode>zijde</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l2_w7">
+          <Coords points="4791,342 4791,402 4830,402 4830,342"/>
+          <TextEquiv>
+            <Unicode>te</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>daarndt voor zoorentrekkende tet veschuld zijde te</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l3" custom="readingOrder {index:2;}">
+        <Coords points="3073,466 3114,478 3176,467 3224,488 3288,468 3371,480 3497,470 3517,484 3556,468 3634,497 3737,470 3900,518 3953,484 3999,475 4063,487 4090,508 4159,483 4195,511 4289,514 4324,501 4376,520 4413,499 4479,521 4516,500 4592,508 4610,490 4716,488 4770,516 4851,483 4851,421 4817,414 4787,430 4751,399 4702,436 4624,449 4551,411 4503,445 4398,442 4265,395 4182,445 4155,426 4130,437 4089,398 4063,420 4022,397 3972,420 3933,396 3878,428 3841,405 3800,432 3772,432 3665,403 3557,434 3529,418 3486,431 3451,417 3369,435 3335,427 3294,386 3257,406 3223,387 3183,415 3142,407 3105,437 3073,434 3073,466"/>
+        <Baseline points="3084,458 3171,458 3259,458 3347,458 3435,458 3523,460 3610,460 3698,462 3786,464 3874,466 3962,466 4049,468 4137,470 4225,470 4313,472 4401,472 4488,472 4576,471 4664,470 4752,468 4840,466"/>
+        <Word id="r9l3_w1">
+          <Coords points="3073,418 3073,478 3868,478 3868,418"/>
+          <TextEquiv>
+            <Unicode>verkalenmenmder</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l3_w2">
+          <Coords points="3966,427 3966,487 4059,487 4059,427"/>
+          <TextEquiv>
+            <Unicode>tot</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l3_w3">
+          <Coords points="4100,430 4100,490 4274,490 4274,430"/>
+          <TextEquiv>
+            <Unicode>recht</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l3_w4">
+          <Coords points="4326,432 4326,492 4433,492 4433,432"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l3_w5">
+          <Coords points="4490,431 4490,491 4588,491 4588,431"/>
+          <TextEquiv>
+            <Unicode>den</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l3_w6">
+          <Coords points="4634,428 4634,488 4834,488 4834,428"/>
+          <TextEquiv>
+            <Unicode>schuld</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>verkalenmenmder tot recht van den schuld</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l4" custom="readingOrder {index:3;}">
+        <Coords points="3076,551 3133,570 3165,554 3273,562 3294,551 3330,588 3392,552 3488,572 3504,556 3571,570 3610,552 3658,553 3733,577 3802,564 3857,585 3947,565 4045,596 4082,571 4123,574 4124,501 4007,522 3954,496 3853,525 3794,515 3762,483 3684,516 3626,520 3558,481 3537,490 3505,476 3445,509 3420,500 3406,511 3315,510 3267,478 3205,514 3077,496 3076,551"/>
+        <Baseline points="3088,546 3139,544 3190,544 3241,544 3292,544 3344,542 3395,544 3446,544 3497,544 3548,544 3600,544 3651,546 3702,546 3753,548 3804,548 3856,550 3907,550 3958,552 4009,552 4060,554 4112,556"/>
+        <Word id="r9l4_w1">
+          <Coords points="3075,504 3075,564 3290,564 3290,504"/>
+          <TextEquiv>
+            <Unicode>risiten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l4_w2">
+          <Coords points="3325,502 3325,562 3383,562 3383,502"/>
+          <TextEquiv>
+            <Unicode>op</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l4_w3">
+          <Coords points="3437,504 3437,564 3516,564 3516,504"/>
+          <TextEquiv>
+            <Unicode>tet</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l4_w4">
+          <Coords points="3575,507 3575,567 3908,567 3908,507"/>
+          <TextEquiv>
+            <Unicode>ooermand</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l4_w5">
+          <Coords points="3956,512 3956,572 4089,572 4089,512"/>
+          <TextEquiv>
+            <Unicode>zelf</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>risiten op tet ooermand zelf</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l5" custom="readingOrder {index:4;}">
+        <Coords points="3067,644 3219,652 3271,639 3500,665 3620,643 3672,656 3734,698 3766,696 3805,657 3963,650 4014,662 4032,646 4098,663 4117,647 4234,660 4371,652 4412,671 4518,656 4644,676 4779,655 4845,679 4875,661 4876,590 4835,587 4800,612 4739,565 4688,608 4603,623 4566,602 4504,624 4427,575 4395,579 4349,616 4257,598 4156,609 4109,574 4076,573 4046,596 4021,586 3941,615 3920,604 3849,619 3765,599 3696,557 3556,574 3534,560 3488,571 3469,561 3442,577 3385,558 3322,583 3291,552 3277,566 3243,554 3217,577 3068,564 3067,644"/>
+        <Baseline points="3080,628 3169,630 3258,630 3347,632 3436,632 3526,634 3615,634 3704,636 3793,638 3882,640 3972,640 4061,642 4150,644 4239,644 4328,646 4418,646 4507,646 4596,648 4685,647 4774,646 4864,646"/>
+        <Word id="r9l5_w1">
+          <Coords points="3088,590 3088,650 3400,650 3400,590"/>
+          <TextEquiv>
+            <Unicode>zullende</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l5_w2">
+          <Coords points="3463,593 3463,653 3521,653 3521,593"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l5_w3">
+          <Coords points="3606,596 3606,656 3865,656 3865,596"/>
+          <TextEquiv>
+            <Unicode>ledingen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l5_w4">
+          <Coords points="3917,600 3917,660 4013,660 4013,600"/>
+          <TextEquiv>
+            <Unicode>ons</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l5_w5">
+          <Coords points="4060,604 4060,664 4250,664 4250,604"/>
+          <TextEquiv>
+            <Unicode>hang</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l5_w6">
+          <Coords points="4309,606 4309,666 4483,666 4483,606"/>
+          <TextEquiv>
+            <Unicode>allen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l5_w7">
+          <Coords points="4530,607 4530,667 4626,667 4626,607"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l5_w8">
+          <Coords points="4668,606 4668,666 4858,666 4858,606"/>
+          <TextEquiv>
+            <Unicode>kracht</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>zullende de ledingen ons hang allen van kracht</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l6" custom="readingOrder {index:5;}">
+        <Coords points="3087,735 3124,753 3206,727 3314,740 3387,729 3406,741 3429,729 3846,734 3886,774 3939,788 3967,784 4015,743 4155,740 4210,757 4249,746 4335,797 4381,793 4455,750 4501,744 4558,749 4574,766 4597,761 4661,789 4751,740 4845,734 4861,746 4897,730 4898,650 4788,708 4662,693 4632,704 4616,688 4582,699 4545,674 4506,701 4479,675 4414,695 4376,672 4309,714 4274,712 4211,656 4149,648 4050,663 4030,649 3998,663 3986,651 3940,662 3856,650 3773,704 3709,694 3675,663 3631,690 3574,685 3546,701 3482,682 3461,693 3338,678 3312,691 3223,679 3175,697 3088,675 3087,735"/>
+        <Baseline points="3098,718 3187,718 3276,718 3366,718 3455,720 3545,722 3634,724 3723,726 3813,728 3902,732 3992,734 4081,736 4170,736 4260,738 4349,738 4439,738 4528,738 4617,736 4707,734 4796,730 4886,724"/>
+        <Word id="r9l6_w1">
+          <Coords points="3088,678 3088,738 3211,738 3211,678"/>
+          <TextEquiv>
+            <Unicode>zyn</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l6_w2">
+          <Coords points="3290,678 3290,738 3519,738 3519,678"/>
+          <TextEquiv>
+            <Unicode>winnen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l6_w3">
+          <Coords points="3610,684 3610,744 3739,744 3739,684"/>
+          <TextEquiv>
+            <Unicode>deze</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l6_w4">
+          <Coords points="3811,693 3811,753 4154,753 4154,693"/>
+          <TextEquiv>
+            <Unicode>zypotleek</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l6_w5">
+          <Coords points="4216,698 4216,758 4379,758 4379,698"/>
+          <TextEquiv>
+            <Unicode>eenste</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l6_w6">
+          <Coords points="4446,698 4446,758 4525,758 4525,698"/>
+          <TextEquiv>
+            <Unicode>zal</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l6_w7">
+          <Coords points="4569,696 4569,756 4660,756 4660,696"/>
+          <TextEquiv>
+            <Unicode>zijn</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l6_w8">
+          <Coords points="4687,690 4687,750 4895,750 4895,690"/>
+          <TextEquiv>
+            <Unicode>gewoden</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>zyn winnen deze zypotleek eenste zal zijn gewoden</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l7" custom="readingOrder {index:6;}">
+        <Coords points="3111,811 3219,807 3258,840 3281,820 3352,809 3386,828 3519,816 3574,828 3609,814 3652,831 3989,821 4142,839 4195,826 4236,842 4307,827 4355,871 4426,838 4518,832 4579,876 4722,830 4795,860 4816,844 4880,841 4881,783 4725,798 4681,781 4656,794 4627,769 4574,766 4558,750 4510,779 4448,774 4434,760 4381,794 4333,798 4253,749 4070,742 4029,767 4013,759 3941,788 3916,774 3875,795 3807,741 3738,738 3692,774 3623,787 3591,773 3579,782 3518,735 3430,782 3268,760 3236,769 3170,734 3112,751 3111,811"/>
+        <Baseline points="3124,798 3211,800 3298,802 3385,804 3472,806 3560,808 3647,810 3734,812 3821,814 3908,816 3996,816 4083,818 4170,818 4257,820 4344,820 4432,820 4519,820 4606,820 4693,818 4780,816 4868,814"/>
+        <Word id="r9l7_w1">
+          <Coords points="3122,763 3122,823 3569,823 3569,763"/>
+          <TextEquiv>
+            <Unicode>Compararten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l7_w2">
+          <Coords points="3636,772 3636,832 3918,832 3918,772"/>
+          <TextEquiv>
+            <Unicode>verklaren</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l7_w3">
+          <Coords points="3978,776 3978,836 4050,836 4050,776"/>
+          <TextEquiv>
+            <Unicode>tot</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l7_w4">
+          <Coords points="4105,778 4105,838 4155,838 4155,778"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l7_w5">
+          <Coords points="4199,780 4199,840 4768,840 4768,780"/>
+          <TextEquiv>
+            <Unicode>timntooerlegzing</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l7_w6">
+          <Coords points="4796,774 4796,834 4873,834 4873,774"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>Compararten verklaren tot de timntooerlegzing van</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l8" custom="readingOrder {index:7;}">
+        <Coords points="3074,903 3159,895 3184,914 3230,896 3298,913 3324,897 3408,896 3469,955 3555,905 3612,902 3672,902 3699,921 3777,904 3839,919 3860,907 3944,918 3997,907 4123,923 4171,909 4208,926 4254,911 4364,912 4599,952 4712,915 4808,921 4809,857 4731,835 4655,882 4605,886 4566,876 4521,834 4481,866 4408,849 4355,873 4305,836 4278,838 4243,872 4195,862 4151,873 4121,870 4076,830 4010,843 3959,822 3913,832 3872,869 3826,877 3759,872 3700,832 3666,863 3597,872 3501,822 3375,820 3329,836 3309,815 3265,855 3199,809 3160,829 3075,825 3074,903"/>
+        <Baseline points="3086,888 3171,888 3257,888 3342,888 3428,889 3513,890 3599,892 3684,894 3770,896 3855,898 3941,900 4026,902 4112,904 4197,906 4283,906 4368,908 4454,908 4539,908 4625,906 4710,904 4796,902"/>
+        <Word id="r9l8_w1">
+          <Coords points="3075,848 3075,908 3183,908 3183,848"/>
+          <TextEquiv>
+            <Unicode>alle</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l8_w2">
+          <Coords points="3234,848 3234,908 3576,908 3576,848"/>
+          <TextEquiv>
+            <Unicode>bepalingen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l8_w3">
+          <Coords points="3633,854 3633,914 3786,914 3786,854"/>
+          <TextEquiv>
+            <Unicode>dezer</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l8_w4">
+          <Coords points="3832,858 3832,918 3946,918 3946,858"/>
+          <TextEquiv>
+            <Unicode>akte</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l8_w5">
+          <Coords points="4008,865 4008,925 4316,925 4316,865"/>
+          <TextEquiv>
+            <Unicode>dominhie</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l8_w6">
+          <Coords points="4368,868 4368,928 4413,928 4413,868"/>
+          <TextEquiv>
+            <Unicode>te</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l8_w7">
+          <Coords points="4464,867 4464,927 4646,927 4646,867"/>
+          <TextEquiv>
+            <Unicode>kieren</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l8_w8">
+          <Coords points="4692,863 4692,923 4777,923 4777,863"/>
+          <TextEquiv>
+            <Unicode>ten</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>alle bepalingen dezer akte dominhie te kieren ten</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l9" custom="readingOrder {index:8;}">
+        <Coords points="3070,986 3650,987 3700,1036 3734,1013 3757,1034 3812,1026 3837,1045 3893,995 3913,1009 3948,994 4083,996 4167,1020 4216,1002 4342,1001 4419,1032 4456,1012 4486,1024 4532,1006 4564,1025 4651,1006 4720,1016 4745,1000 4843,1013 4862,1007 4863,924 4833,919 4778,964 4704,972 4672,960 4626,969 4565,945 4505,953 4489,937 4450,962 4416,961 4364,912 4332,912 4255,961 4217,940 4177,956 4114,913 4067,956 4035,965 3965,909 3928,936 3866,910 3777,925 3743,908 3699,921 3621,906 3561,945 3465,957 3399,944 3353,953 3312,913 3293,922 3266,901 3170,923 3145,900 3104,899 3071,901 3070,986"/>
+        <Baseline points="3082,972 3170,972 3258,974 3347,975 3435,976 3524,978 3612,980 3700,982 3789,984 3877,986 3966,988 4054,990 4142,990 4231,992 4319,992 4408,994 4496,994 4584,994 4673,994 4761,992 4850,990"/>
+        <Word id="r9l9_w1">
+          <Coords points="3099,932 3099,992 3322,992 3322,932"/>
+          <TextEquiv>
+            <Unicode>kantne</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l9_w2">
+          <Coords points="3379,935 3379,995 3476,995 3476,935"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l9_w3">
+          <Coords points="3557,939 3557,999 3654,999 3654,939"/>
+          <TextEquiv>
+            <Unicode>den</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l9_w4">
+          <Coords points="3699,945 3699,1005 4003,1005 4003,945"/>
+          <TextEquiv>
+            <Unicode>tijdelijken</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l9_w5">
+          <Coords points="4071,951 4071,1011 4380,1011 4380,951"/>
+          <TextEquiv>
+            <Unicode>bewoarden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l9_w6">
+          <Coords points="4443,954 4443,1014 4591,1014 4591,954"/>
+          <TextEquiv>
+            <Unicode>dezer</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l9_w7">
+          <Coords points="4637,952 4637,1012 4860,1012 4860,952"/>
+          <TextEquiv>
+            <Unicode>minute</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>kantne van den tijdelijken bewoarden dezer minute</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l10" custom="readingOrder {index:9;}">
+        <Coords points="3089,1074 3504,1075 3577,1131 3785,1117 3841,1083 3882,1095 3944,1082 3967,1099 4116,1087 4188,1136 4234,1134 4260,1109 4326,1089 4530,1090 4553,1104 4659,1089 4677,1101 4695,1089 4777,1118 4814,1105 4858,1114 4859,1004 4815,1018 4786,1004 4760,1017 4731,1007 4685,1023 4660,1007 4574,1049 4531,1021 4513,1035 4456,1013 4373,1053 4305,1004 4245,999 4203,1028 4107,1009 4061,1045 4000,1001 3950,993 3931,1007 3897,997 3843,1045 3798,1051 3772,1048 3734,1013 3706,1036 3669,1035 3610,987 3528,997 3472,1038 3413,1025 3365,1045 3305,1038 3269,1001 3248,1012 3200,988 3142,1031 3090,1033 3089,1074"/>
+        <Baseline points="3100,1058 3187,1060 3274,1063 3361,1066 3449,1068 3536,1070 3623,1072 3711,1074 3798,1076 3885,1077 3973,1078 4060,1080 4147,1080 4234,1080 4322,1082 4409,1082 4496,1082 4584,1080 4671,1080 4758,1080 4846,1078"/>
+        <Word id="r9l10_w1">
+          <Coords points="3104,1021 3104,1081 3328,1081 3328,1021"/>
+          <TextEquiv>
+            <Unicode>Aldus</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l10_w2">
+          <Coords points="3385,1029 3385,1089 3608,1089 3608,1029"/>
+          <TextEquiv>
+            <Unicode>verleden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l10_w3">
+          <Coords points="3679,1033 3679,1093 3724,1093 3724,1033"/>
+          <TextEquiv>
+            <Unicode>te</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l10_w4">
+          <Coords points="3787,1037 3787,1097 4036,1097 4036,1037"/>
+          <TextEquiv>
+            <Unicode>steten,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l10_w5">
+          <Coords points="4049,1040 4049,1100 4139,1100 4139,1040"/>
+          <TextEquiv>
+            <Unicode>ten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l10_w6">
+          <Coords points="4190,1040 4190,1100 4312,1100 4312,1040"/>
+          <TextEquiv>
+            <Unicode>tijde</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l10_w7">
+          <Coords points="4382,1042 4382,1102 4433,1102 4433,1042"/>
+          <TextEquiv>
+            <Unicode>ak</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l10_w8">
+          <Coords points="4472,1041 4472,1101 4542,1101 4542,1041"/>
+          <TextEquiv>
+            <Unicode>in</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l10_w9">
+          <Coords points="4592,1040 4592,1100 4676,1100 4676,1040"/>
+          <TextEquiv>
+            <Unicode>het</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l10_w10">
+          <Coords points="4708,1039 4708,1099 4822,1099 4822,1039"/>
+          <TextEquiv>
+            <Unicode>koop</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>Aldus verleden te steten, ten tijde ak in het koop</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l11" custom="readingOrder {index:10;}">
+        <Coords points="3076,1159 3131,1153 3158,1170 3175,1154 3257,1153 3305,1170 3360,1155 3385,1170 3429,1157 3545,1205 3621,1163 3710,1181 3814,1166 3864,1181 3899,1170 3921,1185 3965,1172 3983,1186 4002,1172 4027,1187 4054,1169 4066,1180 4267,1177 4297,1190 4315,1178 4363,1189 4391,1173 4416,1190 4732,1191 4760,1182 4761,1132 4719,1147 4699,1131 4621,1125 4603,1108 4539,1114 4507,1095 4447,1128 4390,1097 4323,1140 4294,1123 4186,1137 4099,1089 4031,1093 3975,1137 3945,1142 3866,1080 3755,1124 3611,1121 3553,1134 3485,1082 3440,1074 3389,1087 3349,1121 3262,1122 3201,1116 3162,1081 3110,1068 3078,1074 3076,1159"/>
+        <Baseline points="3088,1144 3171,1146 3254,1148 3337,1150 3420,1152 3503,1154 3586,1155 3669,1156 3752,1159 3835,1161 3918,1162 4001,1164 4084,1166 4167,1168 4250,1168 4333,1170 4416,1172 4499,1172 4582,1174 4665,1174 4748,1174"/>
+        <Word id="r9l11_w1">
+          <Coords points="3083,1105 3083,1165 3254,1165 3254,1105"/>
+          <TextEquiv>
+            <Unicode>dezen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l11_w2">
+          <Coords points="3301,1110 3301,1170 3415,1170 3415,1110"/>
+          <TextEquiv>
+            <Unicode>akte</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l11_w3">
+          <Coords points="3478,1114 3478,1174 3530,1174 3530,1114"/>
+          <TextEquiv>
+            <Unicode>is</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l11_w4">
+          <Coords points="3582,1116 3582,1176 3805,1176 3805,1116"/>
+          <TextEquiv>
+            <Unicode>gemeld</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l11_w5">
+          <Coords points="3874,1121 3874,1181 3943,1181 3943,1121"/>
+          <TextEquiv>
+            <Unicode>in</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l11_w6">
+          <Coords points="3989,1128 3989,1188 4551,1188 4551,1128"/>
+          <TextEquiv>
+            <Unicode>tegenwoordigheid</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l11_w7">
+          <Coords points="4597,1134 4597,1194 4706,1194 4706,1134"/>
+          <TextEquiv>
+            <Unicode>van</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>dezen akte is gemeld in tegenwoordigheid van</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l12" custom="readingOrder {index:11;}">
+        <Coords points="3080,1252 3135,1235 3217,1264 3247,1244 3316,1264 3360,1240 3504,1247 3529,1268 3591,1251 3687,1265 3712,1249 3888,1264 3921,1253 3991,1273 4033,1256 4067,1268 4141,1258 4186,1277 4202,1264 4370,1274 4388,1263 4422,1275 4457,1267 4500,1288 4530,1279 4561,1305 4608,1270 4821,1272 4823,1185 4752,1179 4736,1194 4692,1184 4664,1195 4642,1183 4603,1198 4564,1184 4527,1213 4504,1213 4422,1183 4387,1208 4369,1194 4327,1230 4281,1229 4195,1183 4167,1206 4133,1205 4085,1174 4055,1185 4044,1173 3997,1214 3890,1170 3855,1199 3793,1214 3673,1163 3652,1175 3604,1167 3546,1207 3451,1161 3395,1204 3319,1207 3285,1201 3238,1155 3162,1167 3107,1152 3082,1158 3080,1252"/>
+        <Baseline points="3092,1226 3177,1228 3263,1232 3349,1234 3435,1236 3521,1238 3607,1240 3693,1242 3779,1244 3865,1246 3951,1248 4036,1250 4122,1251 4208,1252 4294,1254 4380,1256 4466,1256 4552,1258 4638,1260 4724,1260 4810,1262"/>
+        <Word id="r9l12_w1">
+          <Coords points="3087,1189 3087,1249 3333,1249 3333,1189"/>
+          <TextEquiv>
+            <Unicode>Harm</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l12_w2">
+          <Coords points="3387,1198 3387,1258 3723,1258 3723,1198"/>
+          <TextEquiv>
+            <Unicode>zanderte,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l12_w3">
+          <Coords points="3741,1205 3741,1265 3980,1265 3980,1205"/>
+          <TextEquiv>
+            <Unicode>notaris</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l12_w4">
+          <Coords points="4004,1210 4004,1270 4166,1270 4166,1210"/>
+          <TextEquiv>
+            <Unicode>Klerk</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l12_w5">
+          <Coords points="4232,1213 4232,1273 4298,1273 4298,1213"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l12_w6">
+          <Coords points="4358,1216 4358,1276 4615,1276 4615,1216"/>
+          <TextEquiv>
+            <Unicode>Koelof</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l12_w7">
+          <Coords points="4670,1220 4670,1280 4825,1280 4825,1220"/>
+          <TextEquiv>
+            <Unicode>hart</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>Harm zanderte, notaris Klerk en Koelof hart</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l13" custom="readingOrder {index:12;}">
+        <Coords points="3085,1339 3280,1328 3339,1352 3413,1329 3456,1359 3532,1342 3593,1355 3614,1342 3651,1354 3667,1338 3763,1354 3878,1342 3916,1366 3967,1344 4070,1357 4107,1346 4143,1363 4194,1348 4336,1350 4445,1371 4478,1360 4505,1374 4636,1356 4716,1360 4752,1386 4787,1354 4853,1372 4855,1262 4816,1275 4775,1267 4710,1321 4642,1267 4603,1273 4559,1307 4525,1281 4470,1275 4454,1289 4415,1274 4394,1294 4323,1295 4291,1313 4202,1265 4147,1280 4044,1265 3993,1303 3954,1300 3902,1262 3801,1251 3746,1266 3712,1249 3684,1265 3483,1261 3448,1290 3397,1296 3357,1254 3295,1262 3254,1248 3221,1266 3114,1245 3086,1252 3085,1339"/>
+        <Baseline points="3096,1318 3183,1320 3270,1322 3357,1324 3445,1326 3532,1328 3619,1330 3707,1332 3794,1334 3881,1336 3969,1338 4056,1339 4143,1341 4230,1342 4318,1344 4405,1346 4492,1346 4580,1348 4667,1348 4754,1348 4842,1348"/>
+        <Word id="r9l13_w1">
+          <Coords points="3103,1280 3103,1340 3278,1340 3278,1280"/>
+          <TextEquiv>
+            <Unicode>laden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l13_w2">
+          <Coords points="3317,1283 3317,1343 3391,1343 3391,1283"/>
+          <TextEquiv>
+            <Unicode>bij</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l13_w3">
+          <Coords points="3431,1286 3431,1346 3516,1346 3516,1286"/>
+          <TextEquiv>
+            <Unicode>den</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l13_w4">
+          <Coords points="3550,1293 3550,1353 3975,1353 3975,1293"/>
+          <TextEquiv>
+            <Unicode>Reehtbank,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l13_w5">
+          <Coords points="3997,1300 3997,1360 4212,1360 4212,1300"/>
+          <TextEquiv>
+            <Unicode>beiden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l13_w6">
+          <Coords points="4269,1305 4269,1365 4518,1365 4518,1305"/>
+          <TextEquiv>
+            <Unicode>wonende</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l13_w7">
+          <Coords points="4586,1308 4586,1368 4632,1368 4632,1308"/>
+          <TextEquiv>
+            <Unicode>te</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l13_w8">
+          <Coords points="4677,1308 4677,1368 4846,1368 4846,1308"/>
+          <TextEquiv>
+            <Unicode>Agen</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>laden bij den Reehtbank, beiden wonende te Agen</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l14" custom="readingOrder {index:13;}">
+        <Coords points="3096,1419 3134,1429 3167,1418 3253,1459 3311,1423 3379,1473 3432,1435 3462,1424 3478,1434 3492,1420 3512,1432 3593,1422 3840,1442 3858,1430 4039,1444 4092,1435 4121,1457 4188,1454 4249,1487 4300,1472 4433,1477 4458,1491 4488,1474 4526,1498 4572,1501 4630,1477 4710,1483 4724,1470 4781,1482 4829,1470 4866,1486 4868,1365 4829,1383 4772,1368 4686,1412 4604,1391 4560,1411 4414,1408 4378,1375 4313,1410 4288,1396 4216,1413 4162,1393 4079,1405 3945,1361 3903,1390 3871,1392 3821,1347 3739,1348 3694,1388 3640,1375 3550,1387 3459,1371 3426,1380 3375,1340 3342,1357 3313,1341 3280,1368 3222,1376 3145,1335 3097,1343 3096,1419"/>
+        <Baseline points="3108,1404 3195,1406 3282,1409 3370,1410 3457,1414 3545,1416 3632,1418 3719,1420 3807,1423 3894,1426 3982,1428 4069,1430 4156,1432 4244,1434 4331,1434 4419,1436 4506,1438 4593,1438 4681,1438 4768,1438 4856,1438"/>
+        <Word id="r9l14_w1">
+          <Coords points="3122,1365 3122,1425 3202,1425 3202,1365"/>
+          <TextEquiv>
+            <Unicode>De</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l14_w2">
+          <Coords points="3252,1372 3252,1432 3586,1432 3586,1372"/>
+          <TextEquiv>
+            <Unicode>getuigen,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l14_w3">
+          <Coords points="3604,1378 3604,1438 3728,1438 3728,1378"/>
+          <TextEquiv>
+            <Unicode>even</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l14_w4">
+          <Coords points="3758,1382 3758,1442 3845,1442 3845,1382"/>
+          <TextEquiv>
+            <Unicode>als</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l14_w5">
+          <Coords points="3907,1386 3907,1446 3962,1446 3962,1386"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l14_w6">
+          <Coords points="4018,1393 4018,1453 4450,1453 4450,1393"/>
+          <TextEquiv>
+            <Unicode>comparanten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l14_w7">
+          <Coords points="4500,1398 4500,1458 4623,1458 4623,1398"/>
+          <TextEquiv>
+            <Unicode>mij</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l14_w8">
+          <Coords points="4660,1398 4660,1458 4870,1458 4870,1398"/>
+          <TextEquiv>
+            <Unicode>notaris</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>De getuigen, even als de comparanten mij notaris</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l15" custom="readingOrder {index:14;}">
+        <Coords points="3084,1508 3336,1512 3336,1421 3293,1427 3254,1464 3167,1418 3084,1430 3084,1508"/>
+        <Baseline points="3096,1496 3121,1496 3146,1496 3172,1496 3197,1496 3222,1496 3248,1496 3273,1496 3298,1496 3324,1496"/>
+        <Word id="r9l15_w1">
+          <Coords points="3085,1456 3085,1516 3326,1516 3326,1456"/>
+          <TextEquiv>
+            <Unicode>tekend.</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>tekend.</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l16" custom="readingOrder {index:15;}">
+        <Coords points="3079,1586 3162,1588 3182,1602 3247,1588 3372,1609 3554,1591 3702,1620 3744,1600 3922,1612 3968,1601 3998,1614 4069,1604 4126,1617 4158,1606 4254,1643 4277,1637 4304,1665 4370,1662 4412,1626 4444,1627 4491,1670 4514,1670 4549,1641 4646,1644 4685,1624 4779,1643 4834,1614 4864,1622 4865,1569 4824,1580 4790,1567 4727,1589 4609,1549 4462,1559 4437,1538 4349,1572 4306,1548 4258,1570 4215,1537 4162,1570 4084,1568 3974,1537 3852,1571 3752,1559 3715,1570 3606,1526 3576,1534 3544,1511 3480,1504 3439,1522 3386,1502 3290,1509 3267,1524 3228,1500 3200,1520 3148,1503 3081,1513 3079,1586"/>
+        <Baseline points="3090,1576 3178,1577 3266,1578 3354,1580 3442,1582 3530,1584 3618,1586 3706,1588 3794,1590 3882,1594 3971,1596 4059,1599 4147,1602 4235,1604 4323,1606 4411,1610 4499,1610 4587,1612 4675,1614 4763,1614 4852,1614"/>
+        <Word id="r9l16_w1">
+          <Coords points="3081,1536 3081,1596 3164,1596 3164,1536"/>
+          <TextEquiv>
+            <Unicode>En</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l16_w2">
+          <Coords points="3229,1539 3229,1599 3434,1599 3434,1539"/>
+          <TextEquiv>
+            <Unicode>hebben</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l16_w3">
+          <Coords points="3472,1543 3472,1603 3531,1603 3531,1543"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l16_w4">
+          <Coords points="3575,1549 3575,1609 3993,1609 3993,1549"/>
+          <TextEquiv>
+            <Unicode>comparanten</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l16_w5">
+          <Coords points="4051,1561 4051,1621 4186,1621 4186,1561"/>
+          <TextEquiv>
+            <Unicode>met</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l16_w6">
+          <Coords points="4244,1564 4244,1624 4308,1624 4308,1564"/>
+          <TextEquiv>
+            <Unicode>de</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l16_w7">
+          <Coords points="4347,1570 4347,1630 4623,1630 4623,1570"/>
+          <TextEquiv>
+            <Unicode>getuigen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l16_w8">
+          <Coords points="4661,1574 4661,1634 4732,1634 4732,1574"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l16_w9">
+          <Coords points="4777,1574 4777,1634 4867,1634 4867,1574"/>
+          <TextEquiv>
+            <Unicode>mij</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>En hebben de comparanten met de getuigen en mij</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l17" custom="readingOrder {index:16;}">
+        <Coords points="3072,1667 3239,1669 3294,1684 3542,1677 3607,1717 3708,1718 3724,1734 3871,1722 3902,1739 3935,1719 4029,1728 4052,1710 4124,1749 4148,1734 4230,1729 4322,1747 4375,1728 4397,1735 4456,1702 4487,1717 4582,1708 4599,1722 4634,1705 4732,1721 4758,1710 4812,1730 4838,1721 4841,1618 4755,1653 4720,1657 4686,1637 4597,1656 4551,1645 4498,1674 4439,1631 4392,1662 4319,1667 4278,1638 4241,1653 4201,1616 4120,1657 4083,1661 4056,1646 4042,1660 4003,1659 3985,1645 3943,1660 3883,1610 3846,1600 3722,1603 3632,1640 3529,1633 3400,1648 3328,1596 3248,1603 3216,1591 3165,1608 3074,1587 3072,1667"/>
+        <Baseline points="3084,1658 3171,1660 3258,1663 3345,1666 3432,1669 3519,1672 3606,1674 3693,1676 3780,1678 3867,1682 3955,1684 4042,1686 4129,1688 4216,1690 4303,1692 4390,1694 4477,1696 4564,1698 4651,1698 4738,1700 4826,1702"/>
+        <Word id="r9l17_w1">
+          <Coords points="3074,1621 3074,1681 3378,1681 3378,1621"/>
+          <TextEquiv>
+            <Unicode>notaris,</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l17_w2">
+          <Coords points="3391,1634 3391,1694 3843,1694 3843,1634"/>
+          <TextEquiv>
+            <Unicode>onmiddellyk</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l17_w3">
+          <Coords points="3903,1643 3903,1703 3977,1703 3977,1643"/>
+          <TextEquiv>
+            <Unicode>na</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l17_w4">
+          <Coords points="4019,1649 4019,1709 4336,1709 4336,1649"/>
+          <TextEquiv>
+            <Unicode>voorlezng</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l17_w5">
+          <Coords points="4386,1655 4386,1715 4496,1715 4496,1655"/>
+          <TextEquiv>
+            <Unicode>deze</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l17_w6">
+          <Coords points="4562,1658 4562,1718 4807,1718 4807,1658"/>
+          <TextEquiv>
+            <Unicode>minute</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>notaris, onmiddellyk na voorlezng deze minute</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l18" custom="readingOrder {index:17;}">
+        <Coords points="3072,1766 3171,1750 3239,1775 3267,1759 3282,1774 3434,1763 3541,1782 3567,1778 3568,1705 3546,1700 3494,1733 3429,1676 3408,1690 3390,1673 3363,1684 3273,1677 3204,1719 3073,1718 3072,1766"/>
+        <Baseline points="3084,1750 3110,1750 3136,1751 3162,1752 3188,1752 3215,1752 3241,1752 3267,1753 3293,1754 3320,1754 3346,1754 3372,1756 3398,1756 3424,1756 3451,1758 3477,1759 3503,1760 3529,1761 3556,1762"/>
+        <Word id="r9l18_w1">
+          <Coords points="3078,1714 3078,1774 3555,1774 3555,1714"/>
+          <TextEquiv>
+            <Unicode>onderteekend.</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>onderteekend.</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l19" custom="readingOrder {index:18;}">
+        <Coords points="3057,1900 3119,1916 3190,1860 3238,1857 3423,1860 3467,1890 3554,1887 3553,1781 3526,1795 3480,1766 3455,1778 3434,1764 3283,1772 3269,1759 3239,1775 3173,1753 3100,1779 3056,1767 3057,1900"/>
+        <Baseline points="3068,1858 3094,1854 3120,1851 3147,1849 3173,1847 3199,1846 3226,1846 3252,1846 3278,1846 3305,1846 3331,1846 3357,1846 3384,1847 3410,1848 3436,1848 3463,1848 3489,1848 3515,1848 3542,1846"/>
+        <Word id="r9l19_w1">
+          <Coords points="3082,1812 3082,1872 3128,1872 3128,1812"/>
+          <TextEquiv>
+            <Unicode>G</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l19_w2">
+          <Coords points="3202,1806 3202,1866 3494,1866 3494,1806"/>
+          <TextEquiv>
+            <Unicode>Attend</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>G Attend</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l20" custom="readingOrder {index:19;}">
+        <Coords points="4665,1882 4750,1883 4742,1762 4658,1772 4665,1882"/>
+        <Baseline points="4676,1856 4706,1851 4736,1852"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l21" custom="readingOrder {index:20;}">
+        <Coords points="3988,1908 4082,1896 4126,1866 4119,1812 3977,1821 3988,1908"/>
+        <Baseline points="4000,1900 4029,1894 4058,1890 4087,1887 4116,1884"/>
+        <Word id="r9l21_w1">
+          <Coords points="4008,1850 4008,1910 4099,1910 4099,1850"/>
+          <TextEquiv>
+            <Unicode>te</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>te</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l22" custom="readingOrder {index:21;}">
+        <Coords points="3486,2002 3538,1976 3645,1982 3727,1951 3761,1963 3802,1947 3884,1950 3904,1928 3970,1923 3962,1869 3852,1906 3777,1868 3578,1868 3526,1906 3472,1905 3486,2002"/>
+        <Baseline points="3494,1982 3519,1979 3545,1974 3571,1972 3597,1969 3622,1965 3648,1961 3674,1957 3700,1954 3726,1952 3751,1948 3777,1944 3803,1940 3829,1935 3854,1932 3880,1928 3906,1924 3932,1918 3958,1914"/>
+        <Word id="r9l22_w1">
+          <Coords points="3503,1912 3503,1972 3947,1972 3947,1912"/>
+          <TextEquiv>
+            <Unicode>lenmatar</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>lenmatar</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l23" custom="readingOrder {index:22;}">
+        <Coords points="3875,2163 3911,2127 3963,2122 4007,2078 4038,2089 4066,2066 4114,2070 4156,2024 4200,2023 4312,1982 4292,1931 4210,1960 4058,1954 3988,1975 3910,2027 3824,2028 3875,2163"/>
+        <Baseline points="3878,2140 3904,2128 3931,2117 3957,2105 3984,2092 4010,2079 4037,2068 4063,2056 4090,2044 4116,2035 4143,2026 4169,2017 4196,2008 4222,2002 4249,1995 4275,1989 4302,1986"/>
+        <Word id="r9l23_w1">
+          <Coords points="3896,2021 3896,2081 4206,2081 4206,2021"/>
+          <TextEquiv>
+            <Unicode>Aa</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>Aa</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l24" custom="readingOrder {index:23;}">
+        <Coords points="4013,2218 4101,2226 4196,2199 4220,2211 4382,2150 4480,2137 4540,2153 4550,2136 4677,2127 4655,2017 4614,2037 4567,2023 4534,2032 4468,2085 4423,2095 4322,2068 4243,2108 4190,2088 4107,2107 4039,2161 4001,2162 4013,2218"/>
+        <Baseline points="4026,2222 4057,2218 4089,2214 4121,2208 4153,2201 4185,2195 4216,2188 4248,2180 4280,2173 4312,2165 4344,2157 4375,2149 4407,2143 4439,2136 4471,2129 4503,2122 4534,2118 4566,2114 4598,2111 4630,2109 4662,2108"/>
+        <Word id="r9l24_w1">
+          <Coords points="4031,2178 4031,2238 4072,2238 4072,2178"/>
+          <TextEquiv>
+            <Unicode>J</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l24_w2">
+          <Coords points="4221,2102 4221,2162 4600,2162 4600,2102"/>
+          <TextEquiv>
+            <Unicode>Sambere</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>J Sambere</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l25" custom="readingOrder {index:24;}">
+        <Coords points="4012,2439 4098,2456 4122,2437 4147,2444 4201,2390 4229,2389 4264,2356 4437,2366 4484,2321 4515,2312 4634,2320 4651,2314 4636,2244 4505,2253 4477,2287 4461,2279 4414,2301 4325,2289 4305,2305 4250,2279 4214,2306 4175,2290 4142,2311 4073,2293 4024,2315 3988,2313 4012,2439"/>
+        <Baseline points="4018,2410 4048,2406 4079,2400 4110,2393 4141,2387 4172,2381 4202,2374 4233,2367 4264,2359 4295,2353 4326,2344 4356,2338 4387,2331 4418,2324 4449,2317 4480,2310 4510,2307 4541,2301 4572,2296 4603,2293 4634,2288"/>
+        <Word id="r9l25_w1">
+          <Coords points="4039,2348 4039,2408 4231,2408 4231,2348"/>
+          <TextEquiv>
+            <Unicode>Dede</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l25_w2">
+          <Coords points="4272,2275 4272,2335 4635,2335 4635,2275"/>
+          <TextEquiv>
+            <Unicode>keens</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>Dede keens</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l26" custom="readingOrder {index:25;}">
+        <Coords points="3427,2518 3581,2527 3622,2546 3668,2527 3700,2544 3737,2521 3794,2537 3835,2514 3941,2537 4055,2535 4076,2549 4133,2517 4213,2561 4284,2529 4353,2547 4406,2522 4442,2536 4534,2522 4552,2538 4591,2520 4651,2536 4678,2527 4679,2415 4596,2438 4557,2467 4443,2424 4422,2440 4390,2437 4337,2396 4220,2444 4161,2432 4090,2457 4010,2432 3964,2466 3929,2471 3883,2471 3803,2434 3778,2443 3732,2429 3686,2452 3659,2427 3583,2468 3551,2452 3505,2470 3462,2433 3428,2444 3427,2518"/>
+        <Baseline points="3438,2512 3499,2513 3561,2516 3622,2518 3684,2518 3745,2520 3807,2522 3868,2522 3930,2522 3991,2522 4053,2522 4114,2522 4176,2522 4237,2522 4299,2521 4360,2520 4422,2520 4483,2518 4545,2518 4606,2517 4668,2516"/>
+        <Word id="r9l26_w1">
+          <Coords points="4025,2482 4025,2542 4063,2542 4063,2482"/>
+          <TextEquiv>
+            <Unicode>d</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l26_w2">
+          <Coords points="4160,2482 4160,2542 4264,2542 4264,2482"/>
+          <TextEquiv>
+            <Unicode>vyf</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l26_w3">
+          <Coords points="4278,2478 4278,2538 4679,2538 4679,2478"/>
+          <TextEquiv>
+            <Unicode>entintigsten</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>d vyf entintigsten</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l27" custom="readingOrder {index:26;}">
+        <Coords points="3295,2595 3366,2581 3434,2595 3457,2586 3494,2623 3549,2589 3613,2580 3643,2594 3748,2588 3785,2609 3801,2595 3872,2609 3987,2586 4062,2628 4110,2599 4151,2612 4211,2588 4271,2585 4351,2600 4394,2577 4408,2591 4470,2584 4529,2626 4571,2607 4571,2534 4537,2518 4466,2550 4406,2522 4353,2547 4280,2556 4232,2544 4209,2562 4170,2537 4069,2548 4021,2534 3980,2548 3845,2529 3813,2556 3765,2521 3726,2544 3668,2528 3622,2546 3478,2548 3432,2515 3380,2540 3295,2533 3295,2595"/>
+        <Baseline points="3306,2572 3368,2574 3431,2576 3494,2576 3556,2578 3619,2578 3682,2578 3744,2578 3807,2580 3870,2580 3933,2580 3995,2580 4058,2580 4121,2580 4183,2580 4246,2580 4309,2580 4371,2580 4434,2580 4497,2580 4560,2580"/>
+        <Word id="r9l27_w1">
+          <Coords points="3302,2536 3302,2596 3729,2596 3729,2536"/>
+          <TextEquiv>
+            <Unicode>Augustus</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l27_w2">
+          <Coords points="3802,2540 3802,2600 3927,2600 3927,2540"/>
+          <TextEquiv>
+            <Unicode>1800</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l27_w3">
+          <Coords points="3968,2540 3968,2600 4148,2600 4148,2540"/>
+          <TextEquiv>
+            <Unicode>negen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l27_w4">
+          <Coords points="4184,2540 4184,2600 4242,2600 4242,2540"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l27_w5">
+          <Coords points="4278,2540 4278,2600 4552,2600 4552,2540"/>
+          <TextEquiv>
+            <Unicode>negentig</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>Augustus 1800 negen en negentig</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l28" custom="readingOrder {index:27;}">
+        <Coords points="3288,2677 3366,2697 3472,2671 3499,2646 3621,2664 3655,2648 3717,2656 3735,2645 3790,2666 3905,2638 3923,2653 4022,2652 4049,2680 4085,2685 4141,2670 4260,2690 4376,2685 4416,2665 4468,2686 4503,2682 4535,2655 4565,2669 4627,2654 4628,2592 4522,2627 4467,2620 4394,2577 4329,2613 4261,2584 4213,2611 4110,2598 4082,2623 3981,2592 3951,2616 3931,2600 3862,2608 3803,2593 3745,2611 3670,2591 3610,2616 3553,2589 3514,2607 3489,2588 3401,2605 3361,2586 3331,2597 3289,2588 3288,2677"/>
+        <Baseline points="3300,2634 3365,2636 3431,2638 3497,2638 3563,2640 3629,2640 3694,2642 3760,2642 3826,2644 3892,2645 3958,2646 4023,2647 4089,2648 4155,2649 4221,2650 4287,2650 4352,2652 4418,2652 4484,2654 4550,2654 4616,2656"/>
+        <Word id="r9l28_w1">
+          <Coords points="3291,2596 3291,2656 3467,2656 3467,2596"/>
+          <TextEquiv>
+            <Unicode>136</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l28_w2">
+          <Coords points="3503,2600 3503,2660 3692,2660 3692,2600"/>
+          <TextEquiv>
+            <Unicode>vobt</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l28_w3">
+          <Coords points="3749,2604 3749,2664 3909,2664 3909,2604"/>
+          <TextEquiv>
+            <Unicode>verso</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l28_w4">
+          <Coords points="3975,2607 3975,2667 4116,2667 4116,2607"/>
+          <TextEquiv>
+            <Unicode>vas</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l28_w5">
+          <Coords points="4208,2610 4208,2670 4359,2670 4359,2610"/>
+          <TextEquiv>
+            <Unicode>Twee</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l28_w6">
+          <Coords points="4434,2614 4434,2674 4597,2674 4597,2614"/>
+          <TextEquiv>
+            <Unicode>deven</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>136 vobt verso vas Twee deven</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l29" custom="readingOrder {index:28;}">
+        <Coords points="3424,2734 3478,2740 3568,2709 3595,2732 3666,2738 3820,2736 3850,2721 3880,2735 3951,2734 3994,2721 4024,2740 4056,2742 4079,2722 4120,2741 4182,2724 4266,2762 4301,2760 4343,2729 4407,2739 4420,2728 4459,2754 4482,2743 4512,2755 4532,2753 4534,2679 4499,2692 4013,2675 3924,2687 3807,2681 3780,2658 3754,2680 3658,2685 3633,2664 3589,2680 3528,2644 3501,2646 3473,2673 3425,2674 3424,2734"/>
+        <Baseline points="3436,2708 3490,2708 3544,2708 3598,2708 3653,2710 3707,2710 3761,2710 3816,2712 3870,2712 3924,2714 3979,2714 4033,2716 4087,2716 4141,2718 4196,2718 4250,2720 4304,2721 4359,2722 4413,2722 4467,2724 4522,2724"/>
+        <Word id="r9l29_w1">
+          <Coords points="3439,2668 3439,2728 3638,2728 3638,2668"/>
+          <TextEquiv>
+            <Unicode>twee</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l29_w2">
+          <Coords points="3746,2672 3746,2732 3989,2732 3989,2672"/>
+          <TextEquiv>
+            <Unicode>renvooren.</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l29_w3">
+          <Coords points="4021,2677 4021,2737 4242,2737 4242,2677"/>
+          <TextEquiv>
+            <Unicode>onvaroen</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l29_w4">
+          <Coords points="4286,2681 4286,2741 4344,2741 4344,2681"/>
+          <TextEquiv>
+            <Unicode>va</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>twee renvooren. onvaroen va</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l30" custom="readingOrder {index:29;}">
+        <Coords points="3444,2814 3492,2814 3551,2854 3593,2843 3638,2848 3654,2865 3725,2845 3767,2857 3827,2821 3882,2810 3955,2809 4001,2826 4070,2806 4154,2853 4248,2864 4369,2840 4420,2859 4484,2830 4551,2831 4551,2765 4517,2780 4400,2765 4276,2775 4260,2763 4221,2779 4137,2752 4056,2774 3878,2774 3786,2752 3752,2772 3683,2764 3645,2732 3599,2733 3551,2710 3509,2741 3445,2736 3444,2814"/>
+        <Baseline points="3456,2804 3510,2804 3564,2804 3618,2804 3672,2804 3727,2804 3781,2806 3835,2806 3889,2806 3943,2808 3998,2808 4052,2810 4106,2810 4160,2812 4214,2812 4269,2814 4323,2814 4377,2815 4431,2816 4485,2816 4540,2816"/>
+        <Word id="r9l30_w1">
+          <Coords points="3453,2764 3453,2824 3925,2824 3925,2764"/>
+          <TextEquiv>
+            <Unicode>bemgelden</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l30_w2">
+          <Coords points="3970,2768 3970,2828 4048,2828 4048,2768"/>
+          <TextEquiv>
+            <Unicode>en</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l30_w3">
+          <Coords points="4087,2772 4087,2832 4365,2832 4365,2772"/>
+          <TextEquiv>
+            <Unicode>twintig</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l30_w4">
+          <Coords points="4397,2776 4397,2836 4520,2836 4520,2776"/>
+          <TextEquiv>
+            <Unicode>cent</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>bemgelden en twintig cent</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l31" custom="readingOrder {index:30;}">
+        <Coords points="4038,2901 4153,2900 4266,2943 4319,2933 4323,2825 4284,2824 4239,2862 4040,2844 4038,2901"/>
+        <Baseline points="4050,2888 4076,2887 4102,2886 4128,2886 4154,2886 4180,2886 4206,2888 4232,2888 4258,2891 4284,2893 4310,2896"/>
+        <Word id="r9l31_w1">
+          <Coords points="4039,2848 4039,2908 4050,2908 4050,2848"/>
+          <TextEquiv>
+            <Unicode>v</Unicode>
+          </TextEquiv>
+        </Word>
+        <Word id="r9l31_w2">
+          <Coords points="4113,2846 4113,2906 4131,2906 4131,2846"/>
+          <TextEquiv>
+            <Unicode>o</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>v o</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l32" custom="readingOrder {index:31;}">
+        <Coords points="3337,3035 3370,3041 3451,3001 3553,2990 3537,2844 3515,2856 3479,2846 3453,2863 3413,2854 3366,2901 3323,2908 3337,3035"/>
+        <Baseline points="3344,2992 3372,2987 3400,2982 3428,2978 3456,2973 3484,2971 3512,2970 3540,2972"/>
+        <Word id="r9l32_w1">
+          <Coords points="3339,2939 3339,2999 3495,2999 3495,2939"/>
+          <TextEquiv>
+            <Unicode>ƒ1.15</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>ƒ1.15</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l33" custom="readingOrder {index:32;}">
+        <Coords points="3864,3074 3970,3085 3998,3062 4066,3071 4099,3055 4188,3056 4205,3036 4244,3035 4271,3054 4342,3049 4373,3028 4429,3043 4455,3022 4499,3026 4494,2964 4434,2962 4406,2985 4372,2985 4331,2958 4282,2952 4241,2987 4199,2981 4122,2925 4071,2928 4026,2964 3955,2944 3901,2957 3878,2982 3857,2978 3864,3074"/>
+        <Baseline points="3876,3072 3906,3068 3937,3066 3967,3062 3998,3059 4029,3056 4059,3054 4090,3052 4120,3049 4151,3046 4182,3044 4212,3041 4243,3039 4273,3038 4304,3035 4335,3034 4365,3032 4396,3032 4426,3030 4457,3029 4488,3028"/>
+        <Word id="r9l33_w1">
+          <Coords points="3904,3010 3904,3070 4306,3070 4306,3010"/>
+          <TextEquiv>
+            <Unicode>toe</Unicode>
+          </TextEquiv>
+        </Word>
+        <TextEquiv>
+          <Unicode>toe</Unicode>
+        </TextEquiv>
+      </TextLine>
+      <TextLine id="r9l34" custom="readingOrder {index:33;}">
+        <Coords points="4586,3160 4627,3167 4650,3066 4611,3050 4586,3160"/>
+        <Baseline points="4600,3146 4618,3150"/>
+        <TextEquiv>
+          <Unicode></Unicode>
+        </TextEquiv>
+      </TextLine>
+    </TextRegion>
+  </Page>
+</PcGts>

--- a/pagexml/analysis/inventory_stats.py
+++ b/pagexml/analysis/inventory_stats.py
@@ -1,8 +1,10 @@
 from typing import Dict, List, Tuple, Union
 
 import numpy as np
-
 import pagexml.model.physical_document_model as pdm
+
+from scipy.stats import gaussian_kde
+from scipy.signal import find_peaks
 from pagexml.analysis.layout_stats import get_line_widths, find_line_width_boundary_points
 from pagexml.helper.pagexml_helper import regions_overlap
 
@@ -49,6 +51,24 @@ def is_main_text_line(line: pdm.PageXMLTextLine, main_text_min_width: float,
     return main_text_min_width <= line.coords.width <= main_text_max_width
 
 
+def get_line_side_means(line_sides: np.array):
+    """Find peaks in the distribution of points at one side of a set of lines.
+    The sides can be beginning/left or end/right of a set of lines.
+
+    For beginning/left side of lines, the first peak is the indicator for the
+    left side of the main text column.
+    For end/right side of lines, the last peak is the indicator for the
+    right side of the main text column.
+    """
+    # Find peaks
+    kde = gaussian_kde(line_sides)
+    xgrid = np.linspace(line_sides.min(), line_sides.max())
+    pdf = kde.evaluate(xgrid)
+    peak_idxs, _ = find_peaks(pdf)
+
+    return xgrid[peak_idxs]
+
+
 def get_page_main_text_range(pages: List[pdm.PageXMLPage]):
     # split pages into even and odd (verso and recto)
     pages_even = [page for page in pages if page.metadata['page_side'] == 'even']
@@ -77,6 +97,7 @@ def get_page_main_text_range(pages: List[pdm.PageXMLPage]):
     lefts_odd = np.array([line.coords.left for line in main_text_lines_odd])
     rights_even = np.array([line.coords.right for line in main_text_lines_even])
     rights_odd = np.array([line.coords.right for line in main_text_lines_odd])
+
     if len(lefts_even) == 0 or len(lefts_odd) == 0:
         main_text_ranges = {
             'even': pdm.Interval('even', 0, 99999),
@@ -84,9 +105,16 @@ def get_page_main_text_range(pages: List[pdm.PageXMLPage]):
         }
         print(f"no left-right values for inventory {pages[0].metadata['scan_id']}")
     else:
+        left_means_even = get_line_side_means(lefts_even)
+        left_means_odd = get_line_side_means(lefts_odd)
+        right_means_even = get_line_side_means(rights_even)
+        right_means_odd = get_line_side_means(rights_odd)
+        left_means_even, left_means_odd, right_means_even, right_means_odd
         main_text_ranges = {
-            'even': pdm.Interval('even', int(lefts_even.mean()), int(rights_even.mean())),
-            'odd': pdm.Interval('odd', int(lefts_odd.mean()), int(rights_odd.mean())),
+            # 'even': pdm.Interval('even', int(lefts_even.mean()), int(rights_even.mean())),
+            # 'odd': pdm.Interval('odd', int(lefts_odd.mean()), int(rights_odd.mean())),
+            'even': pdm.Interval('even', int(left_means_even[0]), int(right_means_even[-1])),
+            'odd': pdm.Interval('odd', int(left_means_odd[0]), int(right_means_odd[-1])),
         }
     return main_text_ranges
 

--- a/pagexml/analysis/layout_stats.py
+++ b/pagexml/analysis/layout_stats.py
@@ -303,7 +303,8 @@ def get_text_heights(line: pdm.PageXMLTextLine, step: int = 50,
             height[x] = int_base[x] - int_above[x]
 
     if len(height) == 0:
-        print()
+        if debug > 1:
+            print(f"layout_stats.get_text_heights - no text, no height")
         return None
     return np.array(list(height.values()))
 

--- a/pagexml/analysis/stats.py
+++ b/pagexml/analysis/stats.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import Dict, List, Union
 
 import numpy as np
@@ -10,7 +11,62 @@ import pagexml.model.physical_document_model as pdm
 DEFAULT_ELEMENTS = ['lines', 'words', 'text_regions', 'columns', 'extra', 'pages']
 
 
-def derive_boundary_points(pagexml_doc: pdm.PageXMLTextRegion) -> List[int]:
+def get_doc_metadata(doc: pdm.PageXMLRegion):
+    return {
+        'doc_id': doc.id,
+        'doc_coords': doc.coords.box_string,
+        'doc_width': doc.coords.width,
+        'doc_height': doc.coords.height,
+    }
+
+
+def get_doc_line_stats(doc: pdm.PageXMLRegion, line_width_boundary_points: List[int] = None,
+                       line_bin_width: int = 300, max_bin: int = 3000):
+    """
+
+    :param doc: a PageXML document
+    :param line_width_boundary_points: a list of points indicating boundaries between categories of
+        line widths
+    :type line_width_boundary_points: List[int]
+    :param line_bin_width: width of line bins, to aggregate lines of different lengths
+    :type line_bin_width: int
+    :param max_bin: max line width bin
+    :type max_bin: int
+    """
+    if line_width_boundary_points is None:
+        line_width_boundary_points = [point for point in range(line_bin_width, max_bin, line_bin_width)]
+    lines = [line for line in doc.get_lines() if line.text is not None]
+    wpl_stats = text_stats.get_words_per_line(lines, alpha_words_only=False)
+    awpl_stats = text_stats.get_words_per_line(lines, alpha_words_only=True)
+    line_stats = {}
+    for wpl_cat in text_stats.wpl_cat_range.values():
+        line_stats[f'words_per_line_{wpl_cat}'] = wpl_stats[wpl_cat]
+    for wpl_cat in text_stats.wpl_cat_range.values():
+        line_stats[f'alpha_words_per_line_{wpl_cat}'] = awpl_stats[wpl_cat]
+    line_width_stats = layout_stats.get_line_width_stats(lines, line_width_boundary_points)
+    for line_width_range in line_width_stats:
+        line_stats[f'line_width_range_{line_width_range}'] = line_width_stats[line_width_range]
+    return line_stats
+
+
+def get_doc_word_stats(doc: pdm.PageXMLRegion, stop_words: List[str] = None,
+                       max_word_length: int = 30, use_re_word_boundaries: bool = False):
+    """Return a dictionary with statistics on the words in a PageXML document.
+
+    :param doc: a PageXML document
+    :param stop_words: a list of stopwords to include in number of stopwords the scan statistics
+    :type stop_words: List[str],
+    :param max_word_length: max word length above which words are considered oversized
+    :type max_word_length: int
+    :param use_re_word_boundaries: flag whether to use RegEx word boundaries for word count
+    :type use_re_word_boundaries: bool
+    """
+    words = text_stats.get_doc_words(doc, use_re_word_boundaries=use_re_word_boundaries)
+    return text_stats.get_word_cat_stats(words, stop_words=stop_words,
+                                         max_word_length=max_word_length)
+
+
+def derive_boundary_points(pagexml_doc: pdm.PageXMLRegion) -> List[int]:
     bin_width = pagexml_doc.coords.width / 5
     return [point for point in np.arange(bin_width, pagexml_doc.coords.width, bin_width)]
 
@@ -35,12 +91,13 @@ def _init_doc_stats(line_width_boundary_points: List[int],
     return doc_stats
 
 
-def get_doc_stats(pagexml_docs: Union[pdm.PageXMLTextRegion, List[pdm.PageXMLTextRegion]],
-                  line_width_boundary_points: List[int] = None,
-                  stop_words: List[str] = None,
-                  max_word_length: int = 30, doc_num: int = None,
-                  use_re_word_boundaries: bool = False,
-                  line_bin_width: int = 300, max_bin: int = 3000) -> Dict[str, List[any]]:
+def get_scan_stats(pagexml_docs: Union[pdm.PageXMLRegion, List[pdm.PageXMLRegion]],
+                   line_width_boundary_points: List[int] = None,
+                   stop_words: List[str] = None,
+                   max_word_length: int = 30, doc_num: int = None,
+                   use_re_word_boundaries: bool = False,
+                   use_region_level: bool = False,
+                   line_bin_width: int = 300, max_bin: int = 3000):
     """Generate basic statistics for a PageXML scan object (number of text regions, lines,
     words, etc.).
 
@@ -49,7 +106,106 @@ def get_doc_stats(pagexml_docs: Union[pdm.PageXMLTextRegion, List[pdm.PageXMLTex
     the width of the pagexml_doc.
 
     :param pagexml_docs: a PageXML document object or a list of PageXML document objects
-    :type pagexml_docs: PageXMLTextRegion
+    :type pagexml_docs: PageXMLRegion
+    :param line_width_boundary_points: a list of points indicating boundaries between categories of
+        line widths
+    :type line_width_boundary_points: List[int]
+    :param stop_words: a list of stopwords to include in number of stopwords the scan statistics
+    :type stop_words: List[str],
+    :param max_word_length: max word length above which words are considered oversized
+    :type max_word_length: int
+    :param use_re_word_boundaries: flag whether to use RegEx word boundaries for word count
+    :type use_re_word_boundaries: bool
+    :param use_region_level: flag whether to generates stats per text region instead of per document
+    :type use_region_level: bool
+    :param line_bin_width: width of line bins, to aggregate lines of different lengths
+    :type line_bin_width: int
+    :param max_bin: max line width bin
+    :type max_bin: int
+    :return: a dictionary with scan statistics
+    :rtype: Dict[str, int]
+    """
+    docs_stats = defaultdict(list)
+
+    for pi, pagexml_doc in enumerate(pagexml_docs):
+        continue
+
+
+def get_doc_region_stats(doc: pdm.PageXMLRegion, doc_stats: Dict[str, any],
+                         line_width_boundary_points: List[int] = None,
+                         stop_words: List[str] = None,
+                         max_word_length: int = 30,
+                         use_re_word_boundaries: bool = False,
+                         line_bin_width: int = 300, max_bin: int = 3000):
+    regions_stats = defaultdict(list)
+    for tr in doc.get_inner_text_regions():
+        for field in doc_stats:
+            regions_stats[field].append(doc_stats[field])
+        tr_metadata = get_doc_metadata(tr)
+        for field in tr_metadata:
+            regions_stats[field.replace('doc_', 'text_region_')].append(tr_metadata[field])
+        tr_line_stats = get_doc_line_stats(tr, line_width_boundary_points=line_width_boundary_points,
+                                           line_bin_width=line_bin_width, max_bin=max_bin)
+        tr_word_stats = get_doc_word_stats(tr, stop_words=stop_words, max_word_length=max_word_length,
+                                           use_re_word_boundaries=use_re_word_boundaries)
+        for field in tr_word_stats:
+            regions_stats[field].append(tr_word_stats[field])
+        for field in tr_line_stats:
+            regions_stats[field].append(tr_line_stats[field])
+    return regions_stats
+
+
+def get_doc_stats(docs: Union[pdm.PageXMLRegion, List[pdm.PageXMLRegion]],
+                  line_width_boundary_points: List[int] = None,
+                  use_region_level: bool = False,
+                  stop_words: List[str] = None,
+                  max_word_length: int = 30,
+                  use_re_word_boundaries: bool = False,
+                  line_bin_width: int = 300, max_bin: int = 3000
+                  ):
+    docs_stats = defaultdict(list)
+    if isinstance(docs, pdm.PageXMLRegion):
+        docs = [docs]
+    for di, doc in enumerate(docs):
+        doc_metadata = get_doc_metadata(doc)
+        doc_stats = {'doc_num': di+1}
+        doc_stats.update(doc_metadata)
+        if use_region_level is True:
+            regions_stats = get_doc_region_stats(doc, doc_stats,
+                                                 line_width_boundary_points=line_width_boundary_points,
+                                                 line_bin_width=line_bin_width, max_bin=max_bin,
+                                                 stop_words=stop_words, max_word_length=max_word_length,
+                                                 use_re_word_boundaries=use_re_word_boundaries)
+            for field in regions_stats:
+                docs_stats[field].extend(regions_stats[field])
+        else:
+            doc_stats.update(doc.stats)
+            doc_line_stats = get_doc_line_stats(doc, line_width_boundary_points=line_width_boundary_points,
+                                                line_bin_width=line_bin_width, max_bin=max_bin)
+            doc_word_stats = get_doc_word_stats(doc, stop_words=stop_words, max_word_length=max_word_length,
+                                                use_re_word_boundaries=use_re_word_boundaries)
+            doc_stats.update(doc_word_stats)
+            doc_stats.update(doc_line_stats)
+            for field in doc_stats:
+                docs_stats[field].append(doc_stats[field])
+    return docs_stats
+
+
+def get_doc_stats_old(pagexml_docs: Union[pdm.PageXMLRegion, List[pdm.PageXMLRegion]],
+                      line_width_boundary_points: List[int] = None,
+                      stop_words: List[str] = None,
+                      max_word_length: int = 30, doc_num: int = None,
+                      use_re_word_boundaries: bool = False,
+                      line_bin_width: int = 300, max_bin: int = 3000) -> Dict[str, List[any]]:
+    """Generate basic statistics for a PageXML scan object (number of text regions, lines,
+    words, etc.).
+
+    Line widths are categorised based on a list of boundary points that determine the width of
+    each bin. If no boundary points are passed, a set of boundary points is generated based on
+    the width of the pagexml_doc.
+
+    :param pagexml_docs: a PageXML document object or a list of PageXML document objects
+    :type pagexml_docs: PageXMLRegion
     :param line_width_boundary_points: a list of points indicating boundaries between categories of
         line widths
     :type line_width_boundary_points: List[int]
@@ -71,7 +227,7 @@ def get_doc_stats(pagexml_docs: Union[pdm.PageXMLTextRegion, List[pdm.PageXMLTex
     if line_width_boundary_points is None:
         line_width_boundary_points = [point for point in range(line_bin_width, max_bin, line_bin_width)]
     pagexml_doc_stats = _init_doc_stats(line_width_boundary_points, max_word_length=max_word_length)
-    if isinstance(pagexml_docs, pdm.PageXMLTextRegion):
+    if isinstance(pagexml_docs, pdm.PageXMLRegion):
         pagexml_docs = [pagexml_docs]
     for pi, pagexml_doc in enumerate(pagexml_docs):
         pagexml_doc_stats['doc_id'].append(pagexml_doc.id)

--- a/pagexml/analysis/text_stats.py
+++ b/pagexml/analysis/text_stats.py
@@ -962,7 +962,7 @@ def get_words_per_line(lines: List[pdm.PageXMLTextLine], use_re_word_boundaries:
     return words_per_line
 
 
-def get_doc_words(pagexml_doc: pdm.PageXMLTextRegion, use_re_word_boundaries: bool = False) -> List[str]:
+def get_doc_words(pagexml_doc: pdm.PageXMLRegion, use_re_word_boundaries: bool = False) -> List[str]:
     """Return a list of words that are part of a PageXML pagexml_doc object.
 
     :param pagexml_doc: a PageXML document object

--- a/pagexml/column_parser.py
+++ b/pagexml/column_parser.py
@@ -1,11 +1,13 @@
 import copy
 import re
+import warnings
 from collections import Counter
 from typing import Dict, List, Tuple
 
 import pagexml.helper.pagexml_helper as pagexml_helper
 import pagexml.model.coords as page_coords
 import pagexml.model.physical_document_model as pdm
+import pagexml.parsers.column_parser as column_parser
 
 
 def within_column(line: pdm.PageXMLTextLine, column_range: Dict[str, int],
@@ -15,21 +17,6 @@ def within_column(line: pdm.PageXMLTextLine, column_range: Dict[str, int],
     end = min([line.coords.right, column_range["end"]])
     overlap = end - start if end > start else 0
     return overlap / line.coords.width > overlap_threshold
-
-
-def find_overlapping_columns(columns: List[pdm.PageXMLColumn]):
-    columns.sort()
-    merge_sets = []
-    for ci, curr_col in enumerate(columns[:-1]):
-        next_col = columns[ci + 1]
-        if pdm.is_horizontally_overlapping(curr_col, next_col):
-            for merge_set in merge_sets:
-                if curr_col in merge_set:
-                    merge_set.append(next_col)
-                    break
-            else:
-                merge_sets.append([curr_col, next_col])
-    return merge_sets
 
 
 #################################################
@@ -45,27 +32,23 @@ def compute_pixel_dist(lines: List[pdm.PageXMLTextLine]) -> Counter:
     return pixel_dist
 
 
-def new_gap_pixel_interval(pixel: int) -> dict:
-    return {"start": pixel, "end": pixel}
-
-
 def determine_freq_gap_interval(pixel_dist: Counter, gap_threshold: int) -> list:
     common_pixels = sorted([pixel for pixel, freq in pixel_dist.items()])
     gap_pixel_intervals = []
     if len(common_pixels) == 0:
         return gap_pixel_intervals
-    curr_interval = new_gap_pixel_interval(common_pixels[0])
+    curr_interval = column_parser.new_text_pixel_interval(common_pixels[0])
     prev_interval_end = 0
     for curr_index, curr_pixel in enumerate(common_pixels[:-1]):
         next_pixel = common_pixels[curr_index + 1]
         if next_pixel - curr_pixel < gap_threshold:
-            curr_interval["end"] = next_pixel
+            curr_interval.end = next_pixel
         else:
-            if curr_interval["start"] - prev_interval_end < gap_threshold:
+            if curr_interval.start - prev_interval_end < gap_threshold:
                 continue
             gap_pixel_intervals += [curr_interval]
-            prev_interval_end = curr_interval["end"]
-            curr_interval = new_gap_pixel_interval(next_pixel)
+            prev_interval_end = curr_interval.end
+            curr_interval = column_parser.new_text_pixel_interval(next_pixel)
     gap_pixel_intervals += [curr_interval]
     return gap_pixel_intervals
 
@@ -186,21 +169,6 @@ def make_derived_column(lines: List[pdm.PageXMLTextLine], metadata: dict, page_i
     return column
 
 
-def merge_columns(columns: List[pdm.PageXMLColumn],
-                  doc_id: str, metadata: dict) -> pdm.PageXMLColumn:
-    """Merge a list of columns into one. First, all text regions of all columns are
-    checked for spatial overlap, whereby overlapping text regions are merged.
-    Within the merged text regions, lines are sorted by baseline height."""
-    trs = [tr for col in columns for tr in col.text_regions]
-    merged_tr = pagexml_helper.merge_textregions(trs, metadata)
-    merged_coords = copy.deepcopy(merged_tr.coords)
-    merged_col = pdm.PageXMLColumn(doc_id=doc_id, doc_type='index_column',
-                                   metadata=metadata, coords=merged_coords,
-                                   text_regions=[merged_tr])
-    merged_col.set_as_parent([merged_tr])
-    return merged_col
-
-
 def sort_lines_in_column_ranges(lines: List[pdm.PageXMLTextLine],
                                 column_ranges: List[Dict[str, int]],
                                 overlap_threshold: float,
@@ -230,15 +198,15 @@ def sort_lines_in_column_ranges(lines: List[pdm.PageXMLTextLine],
     return column_lines, extra_lines
 
 
-def merge_overlapping_columns(text_region: pdm.PageXMLTextRegion, columns: List[
-    pdm.PageXMLColumn]):
+def merge_overlapping_columns(text_region: pdm.PageXMLTextRegion,
+                              columns: List[pdm.PageXMLColumn]):
     # column range may have expanded with lines partially overlapping initial range
     # check which extra lines should be added to columns
-    merge_sets = find_overlapping_columns(columns)
+    merge_sets = column_parser.find_overlapping_columns(columns)
     merge_cols = {col for merge_set in merge_sets for col in merge_set}
     non_overlapping_cols = [col for col in columns if col not in merge_cols]
     for merge_set in merge_sets:
-        merged_col = merge_columns(merge_set, "temp_id", merge_set[0].metadata)
+        merged_col = column_parser.merge_columns(merge_set, "temp_id", merge_set[0].metadata)
         if text_region.parent and text_region.parent.id:
             merged_col.set_derived_id(text_region.parent.id)
             merged_col.set_parent(text_region.parent)
@@ -346,8 +314,7 @@ def handle_extra_lines(text_region: pdm.PageXMLTextRegion,
 
 def split_lines_on_column_gaps(text_region: pdm.PageXMLTextRegion,
                                gap_threshold: int = 50,
-                               overlap_threshold: float = 0.5) -> List[
-    pdm.PageXMLColumn]:
+                               overlap_threshold: float = 0.5) -> List[pdm.PageXMLColumn]:
     """Takes a PageXMLTextRegion object and tries to split the lines into columns based
     on a minimum horizontal gap (in number of pixels) between columns.
 
@@ -361,6 +328,9 @@ def split_lines_on_column_gaps(text_region: pdm.PageXMLTextRegion,
         to horizontally overlap at least 50% of the shortest line.
     :type overlap_threshold: float
     """
+    warn_message = ("pagexml.column_parser.split_lines_on_column_gaps is deprecated. "
+                    "Please use pagexml.parser.column_parser.split_lines_on_column_gaps instead")
+    warnings.warn(warn_message, DeprecationWarning)
     column_ranges = find_column_gaps(text_region.get_lines(), gap_threshold=gap_threshold)
     column_ranges = [col_range for col_range in column_ranges if col_range["end"] - col_range["start"] >= 20]
     column_lines, extra_lines = sort_lines_in_column_ranges(text_region.get_lines(),

--- a/pagexml/helper/pagexml_helper.py
+++ b/pagexml/helper/pagexml_helper.py
@@ -134,10 +134,15 @@ def horizontal_group_lines(lines: List[pdm.PageXMLTextLine],
     rest_lines = vertically_sorted[1:]
     if len(vertically_sorted) > 1:
         for li, curr_line in enumerate(rest_lines):
-            prev_line = horizontally_grouped_lines[-1][-1]
+            prev_group = horizontally_grouped_lines[-1]
+            prev_line = prev_group[-1]
             if debug > 0:
                 print(f"prev_line: {prev_line.id} {make_coords_string(prev_line)}")
                 print(f"curr_line: {curr_line.id} {make_coords_string(curr_line)}")
+            if any(curr_line.is_below(pl, direct_only=True) for pl in prev_group):
+                if debug > 0:
+                    print("curr is below prev - new group")
+                horizontally_grouped_lines.append([curr_line])
             if curr_line.is_below(prev_line, direct_only=False):
                 if debug > 0:
                     print("curr is below prev - new group")

--- a/pagexml/helper/pagexml_helper.py
+++ b/pagexml/helper/pagexml_helper.py
@@ -3,6 +3,7 @@ import gzip
 import re
 import string
 from collections import Counter
+from collections import defaultdict
 from enum import Enum
 from typing import Dict, Generator, List, Set, Tuple, Union
 
@@ -47,6 +48,10 @@ def get_region_type(element: pdm.PageXMLDoc) -> RegionType:
 def same_point(point1: Tuple[int, int], point2: Tuple[int, int]) -> bool:
     """Check if two points are the same."""
     return point1[0] == point2[0] and point1[1] == point2[1]
+
+
+def get_doc_indent_left_right(doc, doc_indent: int = 0):
+    return doc.coords.left + doc_indent, doc.coords.right - doc_indent
 
 
 def regions_overlap(region1: pdm.PageXMLDoc, region2: pdm.PageXMLDoc,
@@ -159,6 +164,66 @@ def merge_sets(sets: List[Set[any]], min_overlap: int = 1) -> List[Set[any]]:
         merged_sets.append(merged_set)
 
     return merged_sets
+
+
+def check_lines_are_from_same_table(lines: List[pdm.PageXMLTextLine]) -> pdm.PageXMLTableRegion:
+    first_line = lines[0]
+    first_cell = first_line.parent
+    if not isinstance(first_cell, pdm.PageXMLTableCell):
+        raise TypeError(f"parent of first line in list is not of class PageXMLTableCell, "
+                        f"but instead of {first_cell.__class__.__name__}")
+    first_row = first_cell.parent
+    if not isinstance(first_row, pdm.PageXMLTableRow):
+        raise TypeError(f"parent of cell of first line in list is not of class PageXMLTableRow, "
+                        f"but instead of {first_row.__class__.__name__}")
+    table = first_row.parent
+    if not isinstance(table, pdm.PageXMLTableRegion):
+        raise TypeError(f"parent of row of first line in list is not of class PageXMLTableRegion, "
+                        f"but instead of {table.__class__.__name__}")
+    if any(line.parent.parent.parent != table for line in lines):
+        tables = set(line.parent.parent.parent for line in lines)
+        raise ValueError(f"lines come from multiple tables: {[table.id for table in tables]}")
+    return table
+
+
+def derive_table_region_from_lines(lines: List[pdm.PageXMLTextLine]) -> pdm.PageXMLTableRegion:
+    if len(lines) < 0:
+        raise ValueError(f"cannot derive text_region from empty list of lines.")
+    table = check_lines_are_from_same_table(lines)
+    row_lines = defaultdict(lambda: defaultdict(list))
+    for line in lines:
+        row_lines[line.parent.parent][line.parent].append(copy_line(line))
+    new_table = copy_table_region(table)
+    new_table.rows = []
+    for row in row_lines:
+        new_row = copy_row(row)
+        new_row.set_derived_id(new_table.id)
+        new_row.cells = []
+        for cell in row_lines[row]:
+            new_cell = copy_cell(cell)
+            new_cell.lines = row_lines[row][cell]
+            new_cell.coords = pdm.parse_derived_coords(new_cell.lines)
+            new_cell.set_derived_id(new_row.id)
+            new_row.cells.append(new_cell)
+        new_row.coords = pdm.parse_derived_coords(new_row.cells)
+        new_table.rows.append(new_row)
+    new_table.coords = pdm.parse_derived_coords(new_table.rows)
+    new_table.set_derived_id(table.parent.id)
+    pdm.set_parentage(new_table)
+    return new_table
+
+
+def derive_text_region_from_lines(lines: List[pdm.PageXMLTextLine], parent: pdm.PageXMLRegion = None) -> pdm.PageXMLTextRegion:
+    if len(lines) < 0:
+        raise ValueError(f"cannot derive text_region from empty list of lines.")
+    lines = [copy_line(line) for line in lines]
+    coords = pdm.parse_derived_coords(lines)
+    tr = pdm.PageXMLTextRegion(metadata=copy.deepcopy(lines[0].metadata), coords=coords, lines=lines)
+    if parent:
+        tr.parent = parent
+        tr.set_derived_id(parent.id)
+        tr.set_as_parent(tr.lines)
+    return tr
 
 
 def merge_textregions(text_regions: List[pdm.PageXMLTextRegion],
@@ -630,7 +695,8 @@ def transform_doc_coords(doc, rescale_by: float = None, translate_by: Tuple[int,
     if in_place:
         new_doc = doc
     else:
-        new_doc = copy.deepcopy(doc)
+        # new_doc = copy.deepcopy(doc)
+        new_doc = copy_pagexml_doc(doc)
     if new_doc.coords is None:
         new_coords = None
     else:
@@ -660,3 +726,148 @@ def transform_doc_coords(doc, rescale_by: float = None, translate_by: Tuple[int,
     if rescale_by is not None and hasattr(doc, 'xheight') and doc.xheight is not None:
         doc.xheight = int(doc.xheight * rescale_by)
     return new_doc
+
+
+def copy_pagexml_doc(doc: pdm.PageXMLDoc) -> pdm.PageXMLDoc:
+    parent = doc.parent
+    doc.parent = None
+    new_doc = copy.deepcopy(doc)
+    new_doc.parent = parent
+    return new_doc
+
+
+def copy_doc(doc: pdm.PageXMLDoc) -> pdm.PageXMLDoc:
+    if isinstance(doc, pdm.PageXMLScan):
+        return copy_scan(doc)
+    if isinstance(doc, pdm.PageXMLPage):
+        return copy_page(doc)
+    if isinstance(doc, pdm.PageXMLColumn):
+        return copy_column(doc)
+    if isinstance(doc, pdm.PageXMLTextRegion):
+        return copy_text_region(doc)
+    if isinstance(doc, pdm.PageXMLTextLine):
+        return copy_line(doc)
+    if isinstance(doc, pdm.PageXMLWord):
+        return copy_word(doc)
+    if isinstance(doc, pdm.PageXMLDoc):
+        return copy.deepcopy(doc)
+    else:
+        raise TypeError(f"doc must be an instance of pdm.PageXMLDoc and its sub-classes, not {type(doc)}")
+
+
+def copy_scan(scan: pdm.PageXMLScan) -> pdm.PageXMLScan:
+    new_scan = pdm.PageXMLScan(doc_id=scan.id,
+                               doc_type=copy.deepcopy(scan.type),
+                               metadata=copy.deepcopy(scan.metadata),
+                               coords=copy.deepcopy(scan.coords),
+                               text_regions=[copy_text_region(tr) for tr in scan.text_regions])
+    new_scan.type = copy.deepcopy(scan.type)
+    return new_scan
+
+
+def copy_page(page: pdm.PageXMLPage) -> pdm.PageXMLPage:
+    new_page = pdm.PageXMLPage(doc_id=page.id,
+                               doc_type=copy.deepcopy(page.type),
+                               metadata=copy.deepcopy(page.metadata),
+                               coords=copy.deepcopy(page.coords),
+                               text_regions=[copy_text_region(tr) for tr in page.text_regions],
+                               extra=[copy_region(r) for r in page.extra],
+                               columns=[copy_column(col) for col in page.columns])
+    new_page.type = copy.deepcopy(page.type)
+    return new_page
+
+
+def copy_column(col: pdm.PageXMLColumn) -> pdm.PageXMLColumn:
+    new_col = pdm.PageXMLColumn(doc_id=col.id,
+                                doc_type=copy.deepcopy(col.type),
+                                metadata=copy.deepcopy(col.metadata),
+                                coords=copy.deepcopy(col.coords),
+                                text_regions=[copy_text_region(tr) for tr in col.text_regions])
+    new_col.type = copy.deepcopy(col.type)
+    return new_col
+
+
+def copy_region(region: pdm.PageXMLRegion) -> pdm.PageXMLRegion:
+    """
+    print(f"pagexml_helper.copy_region - region: {region.id} {region.__class__.__name__}")
+    print(f"\tPageXMLTextRegion: {isinstance(region, pdm.PageXMLTextRegion)}")
+    print(f"\tPageXMLTableRegion: {isinstance(region, pdm.PageXMLTableRegion)}")
+    print(f"\tPageXMLEmptyRegion: {isinstance(region, pdm.PageXMLEmptyRegion)}")
+    """
+    if isinstance(region, pdm.PageXMLTextRegion):
+        return copy_text_region(region)
+    if isinstance(region, pdm.PageXMLTableRegion):
+        return copy_table_region(region)
+    if isinstance(region, pdm.PageXMLEmptyRegion):
+        return copy_empty_region(region)
+    new_region = pdm.PageXMLRegion(doc_id=region.id, doc_type=copy.deepcopy(region.type),
+                                   metadata=copy.deepcopy(region.metadata), coords=copy.deepcopy(region.coords),
+                                   text_regions=[copy_text_region(tr) for tr in region.text_regions],
+                                   table_regions=[copy_table_region(tr) for tr in region.table_regions],
+                                   empty_regions=[copy_empty_region(r) for r in region.empty_regions],
+                                   orientation=region.orientation, reading_order=region.reading_order,
+                                   reading_order_attributes=region.reading_order_attributes)
+    return new_region
+
+
+def copy_empty_region(region: pdm.PageXMLEmptyRegion):
+    new_region = pdm.PageXMLEmptyRegion(doc_id=region.id, doc_type=copy.deepcopy(region.type),
+                                        metadata=copy.deepcopy(region.metadata), coords=copy.deepcopy(region.coords),
+                                        orientation=region.orientation)
+    return new_region
+
+
+def copy_text_region(tr: pdm.PageXMLTextRegion) -> pdm.PageXMLTextRegion:
+    new_tr = pdm.PageXMLTextRegion(doc_id=tr.id,
+                                   doc_type=copy.deepcopy(tr.type),
+                                   metadata=copy.deepcopy(tr.metadata),
+                                   coords=copy.deepcopy(tr.coords),
+                                   lines=[copy_line(line) for line in tr.lines],
+                                   text_regions=[copy_text_region(tr) for tr in tr.text_regions])
+    new_tr.type = copy.deepcopy(tr.type)
+    return new_tr
+
+
+def copy_table_region(tr: pdm.PageXMLTableRegion) -> pdm.PageXMLTableRegion:
+    new_tr = pdm.PageXMLTableRegion(doc_id=tr.id,
+                                    doc_type=copy.deepcopy(tr.type),
+                                    metadata=copy.deepcopy(tr.metadata),
+                                    coords=copy.deepcopy(tr.coords),
+                                    rows=[copy_row(row) for row in tr.rows])
+    new_tr.type = copy.deepcopy(tr.type)
+    return new_tr
+
+
+def copy_row(row: pdm.PageXMLTableRow) -> pdm.PageXMLTableRow:
+    new_row = pdm.PageXMLTableRow(doc_id=row.id, metadata=row.metadata, coords=row.coords,
+                                  attrs=row.attrs, cells=[copy_cell(cell) for cell in row.cells],
+                                  orientation=row.orientation)
+    return new_row
+
+
+def copy_cell(cell: pdm.PageXMLTableCell) -> pdm.PageXMLTableCell:
+    new_cell = pdm.PageXMLTableCell(doc_id=cell.id, metadata=cell.metadata, coords=cell.coords,
+                                    attrs=cell.attrs, lines=[copy_line(line) for line in cell.lines],
+                                    orientation=cell.orientation)
+    new_cell.col = cell.col
+    return new_cell
+
+
+def copy_line(line: pdm.PageXMLTextLine) -> pdm.PageXMLTextLine:
+    new_line = pdm.PageXMLTextLine(doc_id=line.id,
+                                   doc_type=copy.deepcopy(line.type),
+                                   metadata=copy.deepcopy(line.metadata),
+                                   coords=copy.deepcopy(line.coords), baseline=copy.deepcopy(line.baseline),
+                                   text=line.text,
+                                   words=[copy_word(word) for word in line.words] if line.words else None)
+    new_line.type = copy.deepcopy(line.type)
+    return new_line
+
+
+def copy_word(word: pdm.PageXMLWord) -> pdm.PageXMLWord:
+    new_word = pdm.PageXMLWord(doc_id=word.id,
+                               doc_type=copy.deepcopy(word.type),
+                               metadata=copy.deepcopy(word.metadata), conf=word.conf,
+                               coords=copy.deepcopy(word.coords), text=word.text)
+    new_word.type = copy.deepcopy(word.type)
+    return new_word

--- a/pagexml/helper/pagexml_helper.py
+++ b/pagexml/helper/pagexml_helper.py
@@ -117,13 +117,14 @@ def sort_regions_in_reading_order(doc: pdm.PageXMLDoc) -> List[pdm.PageXMLTextRe
         return []
 
 
-def horizontal_group_lines(lines: List[pdm.PageXMLTextLine]) -> List[List[pdm.PageXMLTextLine]]:
+def horizontal_group_lines(lines: List[pdm.PageXMLTextLine],
+                           debug: int = 0) -> List[List[pdm.PageXMLTextLine]]:
     """Sort lines of a text region vertically as a list of lists,
     with adjacent lines grouped in inner lists."""
     if len(lines) == 0:
         return []
     # First, sort lines vertically
-    vertically_sorted = [line for line in sorted(lines, key=lambda line: line.coords.top) if line.text is not None]
+    vertically_sorted = [line for line in sorted(lines, key=lambda line: line.baseline.top) if line.text is not None]
     if len(vertically_sorted) == 0:
         # for line in lines:
         #     print(line.coords.box, line.text)
@@ -134,16 +135,20 @@ def horizontal_group_lines(lines: List[pdm.PageXMLTextLine]) -> List[List[pdm.Pa
     if len(vertically_sorted) > 1:
         for li, curr_line in enumerate(rest_lines):
             prev_line = horizontally_grouped_lines[-1][-1]
-            # print(f"prev_line: {prev_line.id} {make_coords_string(prev_line)}")
-            # print(f"curr_line: {curr_line.id} {make_coords_string(curr_line)}")
+            if debug > 0:
+                print(f"prev_line: {prev_line.id} {make_coords_string(prev_line)}")
+                print(f"curr_line: {curr_line.id} {make_coords_string(curr_line)}")
             if curr_line.is_below(prev_line, direct_only=False):
-                # print("curr is below prev - new group")
+                if debug > 0:
+                    print("curr is below prev - new group")
                 horizontally_grouped_lines.append([curr_line])
             elif curr_line.is_next_to(prev_line):
-                # print(f"curr is next to prev - add to last group")
+                if debug > 0:
+                    print(f"curr is next to prev - add to last group")
                 horizontally_grouped_lines[-1].append(curr_line)
             else:
-                # print(f"curr is not next to prev - new group")
+                if debug > 0:
+                    print(f"curr is not next to prev - new group")
                 horizontally_grouped_lines.append([curr_line])
     # Third, sort adjecent lines horizontally
     for line_group in horizontally_grouped_lines:
@@ -151,9 +156,10 @@ def horizontal_group_lines(lines: List[pdm.PageXMLTextLine]) -> List[List[pdm.Pa
     return horizontally_grouped_lines
 
 
-def horizontally_group_lines(lines: List[pdm.PageXMLTextLine]) -> List[List[pdm.PageXMLTextLine]]:
+def horizontally_group_lines(lines: List[pdm.PageXMLTextLine],
+                             debug: int = 0) -> List[List[pdm.PageXMLTextLine]]:
     """Wraps `horizontal_group_lines` but with more appropriate naming."""
-    return horizontal_group_lines(lines)
+    return horizontal_group_lines(lines, debug=debug)
 
 
 def merge_sets(sets: List[Set[any]], min_overlap: int = 1) -> List[Set[any]]:

--- a/pagexml/helper/pagexml_helper.py
+++ b/pagexml/helper/pagexml_helper.py
@@ -134,16 +134,26 @@ def horizontal_group_lines(lines: List[pdm.PageXMLTextLine]) -> List[List[pdm.Pa
     if len(vertically_sorted) > 1:
         for li, curr_line in enumerate(rest_lines):
             prev_line = horizontally_grouped_lines[-1][-1]
-            if curr_line.is_below(prev_line):
+            # print(f"prev_line: {prev_line.id} {make_coords_string(prev_line)}")
+            # print(f"curr_line: {curr_line.id} {make_coords_string(curr_line)}")
+            if curr_line.is_below(prev_line, direct_only=False):
+                # print("curr is below prev - new group")
                 horizontally_grouped_lines.append([curr_line])
             elif curr_line.is_next_to(prev_line):
+                # print(f"curr is next to prev - add to last group")
                 horizontally_grouped_lines[-1].append(curr_line)
             else:
+                # print(f"curr is not next to prev - new group")
                 horizontally_grouped_lines.append([curr_line])
     # Third, sort adjecent lines horizontally
     for line_group in horizontally_grouped_lines:
         line_group.sort(key=lambda line: line.coords.left)
     return horizontally_grouped_lines
+
+
+def horizontally_group_lines(lines: List[pdm.PageXMLTextLine]) -> List[List[pdm.PageXMLTextLine]]:
+    """Wraps `horizontal_group_lines` but with more appropriate naming."""
+    return horizontal_group_lines(lines)
 
 
 def merge_sets(sets: List[Set[any]], min_overlap: int = 1) -> List[Set[any]]:

--- a/pagexml/helper/pagexml_helper.py
+++ b/pagexml/helper/pagexml_helper.py
@@ -141,11 +141,11 @@ def horizontal_group_lines(lines: List[pdm.PageXMLTextLine],
                 print(f"curr_line: {curr_line.id} {make_coords_string(curr_line)}")
             if any(curr_line.is_below(pl, direct_only=True) for pl in prev_group):
                 if debug > 0:
-                    print("curr is below prev - new group")
+                    print("curr is directly below one of prev group - make new group")
                 horizontally_grouped_lines.append([curr_line])
-            if curr_line.is_below(prev_line, direct_only=False):
+            elif curr_line.is_below(prev_line, direct_only=False):
                 if debug > 0:
-                    print("curr is below prev - new group")
+                    print("curr is below prev - make new group")
                 horizontally_grouped_lines.append([curr_line])
             elif curr_line.is_next_to(prev_line):
                 if debug > 0:
@@ -153,7 +153,7 @@ def horizontal_group_lines(lines: List[pdm.PageXMLTextLine],
                 horizontally_grouped_lines[-1].append(curr_line)
             else:
                 if debug > 0:
-                    print(f"curr is not next to prev - new group")
+                    print(f"curr is not next to prev - make new group")
                 horizontally_grouped_lines.append([curr_line])
     # Third, sort adjecent lines horizontally
     for line_group in horizontally_grouped_lines:

--- a/pagexml/helper/spatial_helper.py
+++ b/pagexml/helper/spatial_helper.py
@@ -1,0 +1,219 @@
+from typing import List, Union
+
+from shapely import Polygon
+
+import pagexml.model.pagexml_document_model as pdm
+from pagexml.model.coords import parse_derived_coords
+
+
+INVERSE = {
+    'above': 'below',
+    'below': 'above',
+    'left': 'right',
+    'right': 'left',
+    'over': 'over'
+}
+
+def regions_poly_overlap(region1: pdm.PageXMLRegion, region2: pdm.PageXMLRegion):
+    poly1 = Polygon(region1.coords.points)
+    poly2 = Polygon(region2.coords.points)
+    return poly1.intersects(poly2)
+
+
+def regions_box_overlap_horizontally(region1: pdm.PageXMLRegion, region2: pdm.PageXMLRegion,
+                                     debug: int = 0):
+    max_left = max(region1.coords.left, region2.coords.left)
+    min_right = min(region1.coords.right, region2.coords.right)
+    if debug > 1:
+        print(f"  r1.left: {region1.coords.left}\tr2.left: {region2.coords.left}\tmax_left: {max_left}")
+        print(f"  r1.right: {region1.coords.right}\tr2.right: {region2.coords.right}\tmin_right: {min_right}")
+    return min_right > max_left
+
+
+def regions_box_overlap_vertically(region1: pdm.PageXMLRegion, region2: pdm.PageXMLRegion,
+                                   debug: int = 0):
+    max_top = max(region1.coords.top, region2.coords.top)
+    min_bottom = min(region1.coords.bottom, region2.coords.bottom)
+    if debug > 1:
+        print(f"    r1.top: {region1.coords.top}\tr2.top: {region2.coords.top}\tmax_top: {max_top}")
+        print(f"    r1.bottom: {region1.coords.bottom}\tr2.bottom: {region2.coords.bottom}\tmin_bottom: {min_bottom}")
+    return min_bottom > max_top
+
+
+def regions_box_overlap(region1: pdm.PageXMLRegion, region2: pdm.PageXMLRegion,
+                        debug: int = 0):
+    if debug > 1:
+        print(f"  r1 box: {region1.coords.box}")
+        print(f"  r2 box: {region2.coords.box}")
+    if regions_box_overlap_horizontally(region1, region2, debug=debug) is False:
+        return False
+    if regions_box_overlap_vertically(region1, region2, debug=debug) is False:
+        return False
+    return True
+
+
+def region_touches_left(region1: pdm.PageXMLRegion, region2: pdm.PageXMLRegion,
+                        max_diff_abs: int = None, max_diff_rel: float = None):
+    """Check if the left side of region1 touches the right side of region 2.
+    That is, region 2 is on the left side of region 1 and they are not overlapping
+    but touching. Use `max_diff_abs` to allow for a small absolute margin or
+    `max_diff_rel` for a relative margin."""
+    diff = abs(region1.coords.left - region2.coords.right)
+    rel_diff = diff / region1.coords.width
+    return region_diff_is_touch(diff, rel_diff, max_diff_abs, max_diff_rel)
+
+
+def region_touches_right(region1: pdm.PageXMLRegion, region2: pdm.PageXMLRegion,
+                         max_diff_abs: int = None, max_diff_rel: float = None):
+    """Check if the right side of region1 touches the left side of region 2.
+    That is, region 2 is on the right side of region 1 and they are not overlapping
+    but touching. Use `max_diff_abs` to allow for a small absolute margin or
+    `max_diff_rel` for a relative margin."""
+    diff = abs(region1.coords.right - region2.coords.left)
+    rel_diff = diff / region1.coords.width
+    return region_diff_is_touch(diff, rel_diff, max_diff_abs, max_diff_rel)
+
+
+def region_touches_above(region1: pdm.PageXMLRegion, region2: pdm.PageXMLRegion,
+                         max_diff_abs: int = None, max_diff_rel: float = None):
+    """Check if the top side of region1 touches the bottom side of region 2.
+    That is, region 2 is above region 1 and they are not overlapping
+    but touching. Use `max_diff_abs` to allow for a small absolute margin or
+    `max_diff_rel` for a relative margin."""
+    diff = abs(region1.coords.top - region2.coords.bottom)
+    rel_diff = diff / region1.coords.height
+    return region_diff_is_touch(diff, rel_diff, max_diff_abs, max_diff_rel)
+
+
+def region_touches_below(region1: pdm.PageXMLRegion, region2: pdm.PageXMLRegion,
+                         max_diff_abs: int = None, max_diff_rel: float = None):
+    """Check if the bottom side of region1 touches the top side of region 2.
+    That is, region 2 is below region 1 and they are not overlapping
+    but touching. Use `max_diff_abs` to allow for a small absolute margin or
+    `max_diff_rel` for a relative margin."""
+    diff = abs(region1.coords.bottom - region2.coords.top)
+    rel_diff = diff / region1.coords.height
+    return region_diff_is_touch(diff, rel_diff, max_diff_abs, max_diff_rel)
+
+
+def region_diff_is_touch(diff: int, rel_diff: float, max_diff_abs: int = None,
+                         max_diff_rel: float = None):
+    if max_diff_abs is not None:
+        return diff <= max_diff_abs
+    elif max_diff_rel is not None:
+        return rel_diff <= max_diff_rel
+    else:
+        return diff == 0
+
+
+def get_relative_hloc(region1: pdm.PageXMLRegion, region2: pdm.PageXMLRegion):
+    if region2.coords.right <= region1.coords.left:
+        return 'left'
+    elif region2.coords.left >= region1.coords.right:
+        return 'right'
+    else:
+        return 'over'
+
+
+def get_relative_vloc(region1: pdm.PageXMLRegion, region2: pdm.PageXMLRegion):
+    if region2.coords.bottom <= region1.coords.top:
+        return 'above'
+    elif region2.coords.top >= region1.coords.bottom:
+        return 'below'
+    else:
+        return 'over'
+
+
+def invert_rel_loc(rel_loc: str):
+    if rel_loc not in INVERSE:
+        raise ValueError(f"invalid relative location '{rel_loc}', "
+                         f"must be one of {list(INVERSE.keys())}.")
+    return INVERSE[rel_loc]
+
+
+def line_and_region_align_horizontally(line: pdm.Coords,
+                                       text_region: pdm.PageXMLRegion):
+    """Determine whether a horizontal line and region
+    align at the top or bottom of the region."""
+    return text_region.coords.top == line.top or text_region.coords.bottom == line.top
+
+
+def line_and_region_overlap_horizontally(line: pdm.Coords, text_region: pdm.PageXMLRegion):
+    return text_region.coords.top < line.top < text_region.coords.bottom
+
+
+def get_regions_horizontal_over_line(line: pdm.Coords,
+                                     text_regions: List[pdm.PageXMLRegion],
+                                     boundary_thickness: int = 0):
+    return [tr for tr in text_regions if line_and_region_align_horizontally(line, tr)]
+
+
+def make_empty_region(left: int, top: int, right: int, bottom: int, region_id: str):
+    coords = pdm.Coords([
+        (left, top), (right, top), (right, bottom), (left, bottom)
+    ])
+    return pdm.PageXMLRegion(doc_id=region_id, doc_type='empty_region', coords=coords)
+
+
+def make_region_neighbours(inner_region: pdm.PageXMLRegion, outer_region: pdm.PageXMLRegion,
+                           debug: int = 0):
+    neighbour_regions = []
+    ic = inner_region.coords
+    oc = outer_region.coords
+    if debug > 0:
+        print(f"inner.coords: {ic.box}")
+        print(f"outer.coords: {oc.box}")
+    # check if we need to make an above region
+    if inner_region.coords.top > outer_region.coords.top:
+        above_region = make_empty_region(oc.left, oc.top, oc.right, ic.top, region_id=f'above_{inner_region.id}')
+        neighbour_regions.append(above_region)
+    # check if we need to make a below region
+    if inner_region.coords.bottom < outer_region.coords.bottom:
+        below_region = make_empty_region(oc.left, ic.bottom, oc.right, oc.bottom, region_id=f'below_{inner_region.id}')
+        neighbour_regions.append(below_region)
+    # check if we need to make a left region
+    if inner_region.coords.left > outer_region.coords.left:
+        left_region = make_empty_region(oc.left, ic.top, ic.left, ic.bottom, region_id=f'left_{inner_region.id}')
+        neighbour_regions.append(left_region)
+    # check if we need to make a right region
+    if inner_region.coords.right < outer_region.coords.right:
+        right_region = make_empty_region(ic.right, ic.top, oc.right, ic.bottom, region_id=f'right_{inner_region.id}')
+        neighbour_regions.append(right_region)
+    return neighbour_regions
+
+
+def make_empty_regions(doc: pdm.PageXMLTextRegion, debug: int = 0):
+    if len(doc.lines) > 0:
+        return []
+    if len(doc.text_regions) == 0:
+        return []
+    empty_region = make_empty_region(doc.coords.left, doc.coords.top,
+                                     doc.coords.right, doc.coords.bottom,
+                                     f"empty_{doc.id}")
+    region_exists = set()
+    candidate_regions = [empty_region]
+    non_overlapping_regions: List[pdm.PageXMLRegion] = [tr for tr in doc.text_regions]
+    region_exists.add(empty_region.coords.box_string)
+    empty_regions = []
+    if debug > 0:
+        print(f"initial doc: {doc.id}, candidate_regions: {len(candidate_regions)}, empty: {len(empty_regions)}")
+    while len(candidate_regions) > 0:
+        candidate_region = candidate_regions.pop(0)
+        overlapping_regions = [tr for tr in non_overlapping_regions if regions_box_overlap(tr, candidate_region, debug=debug)]
+        if len(overlapping_regions) == 0:
+            if debug > 0:
+                cr = candidate_region
+                print(f"adding empty region: {cr.id} {cr.coords.box_string}")
+            empty_regions.append(candidate_region)
+            non_overlapping_regions.append(candidate_region)
+        else:
+            tr = overlapping_regions[0]
+            new_regions = make_region_neighbours(tr, candidate_region)
+            candidate_regions.extend(new_regions)
+        if debug > 0:
+            print(f"current candidate: {candidate_region.id}, {candidate_region.coords.box_string} "
+                  f"candidate_regions: {len(candidate_regions)}, "
+                  f"empty: {len(empty_regions)}")
+            for cr in candidate_regions:
+                print(f"\tcandidate: {cr.id}\t{cr.coords.box_string}")
+    return empty_regions

--- a/pagexml/model/basic_document_model.py
+++ b/pagexml/model/basic_document_model.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import re
 
 from typing import Union, List, Dict, Set, Tuple
 
@@ -146,7 +147,11 @@ class PhysicalStructureDoc(StructureDoc):
 
     def set_derived_id(self, parent_id: str):
         box_string = f"{self.coords.x}-{self.coords.y}-{self.coords.w}-{self.coords.h}"
-        self.id = f"{parent_id}-{self.main_type}-{box_string}"
+        if m := re.search(r"(-[a-z_]+-\d+-\d+-\d+-\d+)$", parent_id):
+            parent_box = m.group(1)
+            self.id = parent_id.replace(parent_box, f"-{self.main_type}-{box_string}")
+        else:
+            self.id = f"{parent_id}-{self.main_type}-{box_string}"
         # self.metadata['id'] = self.id
 
     def add_parent_id_to_metadata(self):

--- a/pagexml/model/coords.py
+++ b/pagexml/model/coords.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import List, Tuple, Union
 
 import numpy as np
 from scipy.spatial import QhullError, ConvexHull
+
+
+@dataclass
+class Point:
+
+    x: int
+    y: float
 
 
 def parse_points(points: Union[str, List[Tuple[int, int]]]) -> List[Tuple[int, int]]:
@@ -81,6 +89,15 @@ class Coords:
     def box(self):
         return {"x": self.x, "y": self.y, "w": self.w, "h": self.h}
 
+    @property
+    def box_string(self):
+        return f"{self.x}-{self.y}-{self.w}-{self.h}"
+
+    @staticmethod
+    def coords_from_box_params(x: int, y: int, w: int, h: int):
+        points = [(x, y), (x + w, y), (x + w, y + h), (x, y + h)]
+        return Coords(points=points)
+
 
 class Baseline(Coords):
 
@@ -154,6 +171,10 @@ def coords_list_to_hull_coords(coords_list):
         hull_points = edges_to_hull_points(edges)
         return Coords(hull_points)
     except (IndexError, QhullError):
+        if len(set(point[0] for point in points)) == 1:
+            return Coords(points)
+        if len(set(point[1] for point in points)) == 1:
+            return Coords(points)
         print('pagexml.model.physical_document_model.coords_list_to_hull_coords - IndexError')
         print('coords in coords_list:', [coords for coords in coords_list])
         print('points derived from list of coords:', points)
@@ -185,3 +206,5 @@ def edges_to_hull_points(edges):
     return sorted_nodes
 
 
+def coords_as_span(coords: Coords):
+    return coords.left, coords.right, coords.top, coords.bottom

--- a/pagexml/model/empty_model.py
+++ b/pagexml/model/empty_model.py
@@ -1,0 +1,104 @@
+from collections import defaultdict
+from typing import Dict, List
+
+import pagexml.helper.pagexml_helper as pagexml_helper
+import pagexml.helper.spatial_helper as spatial_helper
+import pagexml.model.pagexml_document_model as pdm
+
+
+def get_region_alignment(doc: pdm.PageXMLTextRegion = None,
+                         regions: List[pdm.PageXMLTextRegion] = None):
+    if doc is None and regions is None:
+        raise ValueError(f"must pass 'doc' or 'regions'.")
+    if doc is not None and regions is not None:
+        raise ValueError(f"must pass either 'doc' or 'regions', not both.")
+    if doc is not None:
+        regions = [region for region in doc.text_regions]
+    rel_loc = {}
+    aligned = {
+        'left': defaultdict(list),
+        'right': defaultdict(list),
+        'above': defaultdict(list),
+        'below': defaultdict(list),
+    }
+    for ci, curr_tr in enumerate(regions):
+        if curr_tr == regions[-1]:
+            break
+        for next_tr in regions[ci+1:]:
+            rel_hloc = spatial_helper.get_relative_hloc(curr_tr, next_tr)
+            rel_vloc = spatial_helper.get_relative_vloc(curr_tr, next_tr)
+            inv_rel_hloc = spatial_helper.invert_rel_loc(rel_hloc)
+            inv_rel_vloc = spatial_helper.invert_rel_loc(rel_vloc)
+            if rel_hloc == 'over' and rel_vloc == 'over':
+                raise ValueError(f"regions overlap both horizontally and vertically:"
+                                 f"\n\t{curr_tr}\n\t{next_tr}")
+            rel_loc[(curr_tr, next_tr)] = (rel_hloc, rel_vloc)
+            rel_loc[(next_tr, curr_tr)] = (inv_rel_hloc, inv_rel_vloc)
+            aligned[rel_vloc][curr_tr].append(next_tr)
+    return rel_loc, aligned
+
+def get_region_top_line(region: pdm.PageXMLRegion):
+    return pdm.Coords([(region.coords.left, region.coords.top), (region.coords.right, region.coords.top)])
+
+
+def get_region_bottom_line(region: pdm.PageXMLRegion):
+    return pdm.Coords([(region.coords.left, region.coords.bottom), (region.coords.right, region.coords.bottom)])
+
+
+def get_region_horizontal_lines(region: pdm.PageXMLTextRegion, doc: pdm.PageXMLTextRegion,
+                                aligned: Dict[str, Dict[pdm.PageXMLTextRegion, List[pdm.PageXMLTextRegion]]]):
+    """Determine the top left, top right, bottom left, bottom right lines between a region
+    and it's neighbours."""
+    if region not in doc.text_regions:
+        raise ValueError(f"region {region.id} is not direct text regions of doc {doc.id}.")
+
+    doc_left, doc_right = doc.coords.left, doc.coords.right
+
+    top_line = get_region_top_line(region)
+    bottom_line = get_region_bottom_line(region)
+
+    if len(aligned['left'][region]) == 0:
+        top_left_boundary = doc_left
+        bottom_left_boundary = doc_left
+    else:
+        top_left_aligned = spatial_helper.get_regions_horizontal_over_line(top_line, aligned['left'][region])
+        right_most_top_aligned = top_left_aligned.index(max([tr.coords.right for tr in top_left_aligned]))
+        top_left_boundary = right_most_top_aligned.coords.right
+        bottom_left_aligned = spatial_helper.get_regions_horizontal_over_line(bottom_line, aligned['left'][region])
+        right_most_bottom_aligned = bottom_left_aligned.index(max([tr.coords.right for tr in bottom_left_aligned]))
+        bottom_left_boundary = right_most_bottom_aligned.coords.right
+    if len(aligned['right'][region]) == 0:
+        top_right_boundary = doc_right
+        bottom_right_boundary = doc_right
+    else:
+        top_right_aligned = spatial_helper.get_regions_horizontal_over_line(top_line, aligned['right'][region])
+        left_most_top_aligned = top_right_aligned.index(min([tr.coords.left for tr in top_right_aligned]))
+        top_right_boundary = left_most_top_aligned.coords.left
+        bottom_right_aligned = spatial_helper.get_regions_horizontal_over_line(bottom_line, aligned['right'][region])
+        left_most_bottom_aligned = bottom_right_aligned.index(min([tr.coords.left for tr in bottom_right_aligned]))
+        bottom_right_boundary = left_most_bottom_aligned.coords.left
+    # top_left_line = pdm.Coords([(top_left_boundary, region.coords.top), (region.coords.left, region.coords.top)])
+    # top_right_line = pdm.Coords([(top_right_boundary, region.coords.top), (region.coords.right, region.coords.top)])
+    top_line = pdm.Coords([(top_left_boundary, region.coords.top), (top_right_boundary, region.coords.top)])
+    bottom_line = pdm.Coords([(bottom_left_boundary, region.coords.bottom), (bottom_right_boundary, region.coords.bottom)])
+    # bottom_left_line = pdm.Coords([(bottom_left_boundary, region.coords.bottom), (region.coords.left, region.coords.bottom)])
+    # bottom_right_line = pdm.Coords([(bottom_right_boundary, region.coords.bottom), (region.coords.right, region.coords.bottom)])
+    # return top_left_line, top_right_line, bottom_left_line, bottom_right_line
+    return top_line, bottom_line
+
+
+def get_doc_horizontal_lines(doc: pdm.PageXMLTextRegion):
+    top_line = get_region_top_line(doc)
+    bottom_line = get_region_bottom_line(doc)
+    horizontal_lines = [top_line, bottom_line]
+    rel_loc, aligned = get_region_alignment(doc=doc)
+    for curr_tr in sorted(doc.text_regions, key = lambda tr: tr.coords.top):
+        # top_left, top_right, bottom_left, bottom_right = get_region_horizontal_lines(curr_tr, doc, aligned)
+        top_line, bottom_line = get_region_horizontal_lines(curr_tr, doc, aligned)
+        horizontal_lines.extend([top_line, bottom_line])
+
+
+
+def get_empty_regions(doc: pdm.PageXMLTextRegion):
+    # make sure there are no overlapping regions
+    return None

--- a/pagexml/model/pagexml_document_model.py
+++ b/pagexml/model/pagexml_document_model.py
@@ -1049,16 +1049,9 @@ class PageXMLPage(PageXMLRegion):
 
     def get_lines(self, ignore_reading_order: bool = False):
         lines = []
-        # First, add lines from columns
-        for column in sorted(self.columns):
-            trs = column.regions
-            for tr in trs:
-                lines += tr.get_lines(ignore_reading_order=ignore_reading_order)
-        # Second, add lines from text_regions
         all_regions = self.get_regions(ignore_reading_order=ignore_reading_order)
-        all_regions.extend(self.extra)
         for tr in all_regions:
-            if isinstance(tr, PageXMLTextRegion) or isinstance(tr, PageXMLTableRegion):
+            if hasattr(tr, 'get_lines'):
                 lines += tr.get_lines()
         return lines
 

--- a/pagexml/model/pagexml_document_model.py
+++ b/pagexml/model/pagexml_document_model.py
@@ -263,21 +263,33 @@ class PageXMLTextLine(PageXMLDoc):
         # print("pagexml.pdm - SELF IS ADJACENT TO OTHER")
         return False
 
-    def is_next_to(self, other: PageXMLTextLine) -> bool:
+    def is_next_to(self, other: PageXMLTextLine, debug: int = 0) -> bool:
         """Test if this line is vertically aligned with the other line."""
-        if get_vertical_overlap(self, other) == 0:
-            # print("NO VERTICAL OVERLAP")
+        vertical_overlap = get_vertical_overlap(self, other)
+        min_height = min(self.text_height, other.text_height)
+        if vertical_overlap == 0:
+            if debug > 0:
+                print("NO VERTICAL OVERLAP")
             return False
         if get_horizontal_overlap(self, other) > 40:
-            # print("TOO MUCH HORIZONTAL OVERLAP", horizontal_overlap(self.coords, other.coords))
+            if debug > 0:
+                print("TOO MUCH HORIZONTAL OVERLAP", get_horizontal_overlap(self, other))
             return False
+        """
         if self.baseline.top > other.baseline.bottom + 10:
-            # print("VERTICAL BASELINE GAP TOO BIG")
+            if debug > 0:
+                print("VERTICAL BASELINE GAP TOO BIG")
             return False
         elif self.baseline.bottom < other.baseline.top - 10:
+            if debug > 0:
+                print("VERTICAL BASELINE GAP TOO BIG")
             return False
-        else:
+        """
+        if vertical_overlap / min_height > 0.5:
+            # print("pagexml.pdm - NO HORIZONTAL OVERLAP, LINES VERTICALLY OVERLAP")
             return True
+        else:
+            return False
 
     def add_to_pagexml(self, parent: etree.Element = None):
         line_xml = add_pagexml_sub_element(parent, 'TextLine', sub_id=self.id, custom=self.custom,

--- a/pagexml/model/pagexml_document_model.py
+++ b/pagexml/model/pagexml_document_model.py
@@ -11,6 +11,13 @@ from pagexml.model.xml import make_empty_pagexml, add_pagexml_sub_element
 import pagexml.model.xml as xml
 
 
+CHILD_PROPERTIES = [
+    'pages', 'columns',
+    'text_regions', 'table_regions', 'empty_regions',
+    'rows', 'cells', 'lines', 'words'
+]
+
+
 class PageXMLDoc(PhysicalStructureDoc):
 
     def __init__(self, doc_id: str = None, doc_type: Union[str, List[str]] = None,
@@ -26,8 +33,8 @@ class PageXMLDoc(PhysicalStructureDoc):
         self.orientation = orientation
         self.pagexml_type = None
         self.attrs = attrs if attrs else {}
-        self.type = 'pagexml_doc'
-        self.add_type('pagexml_doc')
+        self.type = doc_type
+        # self.add_type('pagexml_doc')
 
     @property
     def stats(self):
@@ -281,7 +288,200 @@ def get_num_columns(rows: List[PageXMLTableRow]):
     return max(len(row) for row in rows) if len(rows) > 0 else 0
 
 
-class PageXMLTableRegion(PageXMLDoc):
+class PageXMLRegion(PageXMLDoc):
+
+    def __init__(self, doc_id: str = None, doc_type: Union[str, List[str]] = None,
+                 metadata: Dict[str, any] = None, coords: Coords = None,
+                 attrs: Dict[str, any] = None,
+                 orientation: float = None, reading_order: Dict[int, str] = None,
+                 text_regions: List[PageXMLTextRegion] = None,
+                 table_regions: List[PageXMLTableRegion] = None,
+                 empty_regions: List[PageXMLEmptyRegion] = None,
+                 reading_order_attributes: Dict[str, any] = None):
+        super().__init__(doc_id=doc_id, doc_type=doc_type, attrs=attrs, metadata=metadata,
+                         coords=coords, reading_order=reading_order,
+                         reading_order_attributes=reading_order_attributes, orientation=orientation)
+        self.main_type = doc_type if doc_type is not None else 'region'
+        self.text_regions: List[PageXMLTextRegion] = text_regions if text_regions is not None else []
+        self.table_regions: List[PageXMLTableRegion] = table_regions if table_regions is not None else []
+        self.empty_regions: List[PageXMLEmptyRegion] = empty_regions if empty_regions is not None else []
+        for table in self.table_regions:
+            for row in table.rows:
+                if len(row) < table.num_columns:
+                    row.pad_columns(table.num_columns)
+        for region in self.regions:
+            region.set_parent(self)
+
+    def __repr__(self):
+        content_string = f"\n\tid={self.id}, \n\ttype={self.type}, "
+        return f"{self.__class__.__name__}({content_string}\n)"
+
+    def __lt__(self, other: PageXMLTextRegion):
+        """For sorting text regions. Assumptions: reading from left to right (western bias),
+        top to bottom. If two regions are horizontally overlapping, sort from
+        top to bottom, even if the upper region is more horizontally indented."""
+        if other == self:
+            return False
+        if is_horizontally_overlapping(self, other):
+            return self.coords.top < other.coords.top
+        else:
+            return self.coords.left < other.coords.left
+
+    @property
+    def regions(self):
+        regions = []
+        regions.extend(self.text_regions)
+        regions.extend(self.table_regions)
+        regions.extend(self.empty_regions)
+        return sorted(regions)
+
+    def add_child(self, child: PageXMLDoc):
+        child.set_parent(self)
+        if isinstance(child, PageXMLTextRegion):
+            self.text_regions.append(child)
+        elif isinstance(child, PageXMLTableRegion):
+            self.table_regions.append(child)
+        elif isinstance(child, PageXMLEmptyRegion):
+            self.empty_regions.append(child)
+        else:
+            raise TypeError(f'unknown child type: {child.__class__.__name__}')
+        self.set_as_parent([child])
+        self.coords = parse_derived_coords(self.regions)
+
+    @property
+    def children(self):
+        return self.regions
+
+    @property
+    def num_text_regions(self):
+        return len(self.text_regions)
+
+    @property
+    def num_table_regions(self):
+        return len(self.get_table_regions())
+
+    @property
+    def json(self) -> Dict[str, any]:
+        doc_json = super().json
+        if self.text_regions:
+            doc_json['text_regions'] = [text_region.json for text_region in self.text_regions]
+        if self.table_regions:
+            doc_json['table_regions'] = [table_region.json for table_region in self.table_regions]
+        if self.empty_regions:
+            doc_json['empty_regions'] = [empty_region.json for empty_region in self.empty_regions]
+        if self.orientation:
+            doc_json['orientation'] = self.orientation
+        if self.reading_order_attributes:
+            doc_json['reading_order_attributes'] = self.reading_order_attributes
+        if self.reading_order:
+            doc_json['reading_order'] = self.reading_order
+        doc_json['stats'] = self.stats
+        return doc_json
+
+    def get_text_regions_in_reading_order(self):
+        if not self.reading_order:
+            return self.text_regions
+        tr_ids = list({region_id: None for _index, region_id in sorted(self.reading_order.items(), key=lambda x: x[0])})
+        tr_map = {}
+        for text_region in self.text_regions:
+            # if text_region.id not in tr_ids:
+            #     print("reading order:", self.reading_order)
+            #     raise KeyError(f"text_region with id {text_region.id} is not listed in reading_order")
+            tr_map[text_region.id] = text_region
+        return [tr_map[tr_id] for tr_id in tr_ids if tr_id in tr_map]
+
+    def set_text_regions_in_reading_order(self):
+        tr_ids = [tr.id for tr in self.text_regions]
+        for order_number in self.reading_order:
+            text_region_id = self.reading_order[order_number]
+            self.reading_order_number[text_region_id] = order_number
+        for tr_id in tr_ids:
+            if tr_id not in self.reading_order_number:
+                # there is a text_region that was not in the original PageXML output:
+                # ignore reading order
+                self.reading_order = None
+                return None
+        self.text_regions = self.get_text_regions_in_reading_order()
+
+    def get_all_text_regions(self):
+        text_regions: Set[PageXMLTextRegion] = set()
+        for text_region in self.text_regions:
+            text_regions.add(text_region)
+            if text_region.text_regions:
+                text_regions += text_region.get_all_text_regions()
+        return text_regions
+
+    def get_inner_text_regions(self) -> List[PageXMLTextRegion]:
+        text_regions: List[PageXMLTextRegion] = []
+        for text_region in self.text_regions:
+            if text_region.text_regions:
+                text_regions += text_region.get_inner_text_regions()
+            elif text_region.lines:
+                text_regions.append(text_region)
+        if not self.text_regions and isinstance(self, PageXMLTextRegion):
+            text_regions.append(self)
+        return text_regions
+
+    def get_table_regions(self):
+        table_regions = [tr for tr in self.table_regions]
+        for tr in self.text_regions:
+            table_regions.extend(tr.get_table_regions())
+        return table_regions
+
+    def get_textual_regions(self):
+        return [region for region in self.regions if is_textual_region(region)]
+
+    def get_regions(self, ignore_reading_order: bool = False) -> List[PageXMLDoc]:
+        all_regions = self.regions
+        if self.reading_order and not ignore_reading_order:
+            ordered_regions = [tr for tr in all_regions if tr.id in self.reading_order]
+            unordered_regions = [tr for tr in all_regions if tr.id not in self.reading_order]
+        else:
+            ordered_regions = []
+            unordered_regions = all_regions
+        all_regions = sorted(ordered_regions, key=lambda t: self.reading_order_number[t.id])
+        all_regions.extend(unordered_regions)
+        return all_regions
+
+    def get_lines(self, ignore_reading_order: bool = False):
+        lines = []
+        for tr in self.get_textual_regions():
+            lines.extend(tr.get_lines())
+        return lines
+
+    @property
+    def stats(self):
+        stats = {'lines': 0, 'words': 0, 'chars': 0}
+        if self.text_regions:
+            stats['text_regions'] = len(self.text_regions)
+        if self.table_regions:
+            stats['table_regions'] = len(self.table_regions)
+        if self.empty_regions:
+            stats['empty_regions'] = len(self.empty_regions)
+        for region in self.regions:
+            region_stats = region.stats
+            for field in region_stats:
+                stats[field] = stats.get(field, 0) + region_stats[field]
+        return stats
+
+
+class PageXMLEmptyRegion(PageXMLRegion):
+
+    def __init__(self, doc_id: str = None, doc_type: Union[str, List[str]] = None,
+                 metadata: Dict[str, any] = None, coords: Coords = None,
+                 attrs: Dict[str, any] = None, orientation: float = None):
+        super(PageXMLEmptyRegion, self).__init__(doc_id=doc_id, doc_type='empty_region', metadata=metadata,
+                                                 coords=coords, attrs=attrs, orientation=orientation)
+        self.main_type = 'empty_region'
+        if doc_type:
+            self.add_type(doc_type)
+
+    @property
+    def stats(self):
+        return super(PageXMLEmptyRegion, self).stats
+
+
+class PageXMLTableRegion(PageXMLRegion):
 
     def __init__(self, doc_id: str = None, doc_type: Union[str, List[str]] = None,
                  metadata: Dict[str, any] = None, coords: Coords = None,
@@ -401,7 +601,7 @@ def check_cell_row_consistency(cells: List[PageXMLTableCell]):
         raise ValueError(message)
 
 
-class PageXMLTableRow(PageXMLDoc):
+class PageXMLTableRow(PageXMLRegion):
 
     def __init__(self, doc_id: str = None, doc_type: Union[str, List[str]] = None,
                  metadata: Dict[str, any] = None, coords: Coords = None,
@@ -517,7 +717,7 @@ class PageXMLTableRow(PageXMLDoc):
         self.add_to_pagexml(tr_xml)
 
 
-class PageXMLTableCell(PageXMLDoc):
+class PageXMLTableCell(PageXMLRegion):
 
     def __init__(self, doc_id: str = None, doc_type: Union[str, List[str]] = None,
                  metadata: Dict[str, any] = None, coords: Coords = None,
@@ -609,6 +809,8 @@ class PageXMLTableCell(PageXMLDoc):
                 text = self.cornerpoints
             else:
                 text = ' '.join(str(point) for point in self.cornerpoints)
+        else:
+            text = ''
         add_pagexml_sub_element(cell_xml, 'CornerPts', text=text)
 
     def _to_pagexml(self, page_xml: etree.Element):
@@ -617,26 +819,20 @@ class PageXMLTableCell(PageXMLDoc):
         self.add_to_pagexml(tr_xml)
 
 
-class PageXMLTextRegion(PageXMLDoc):
+class PageXMLTextRegion(PageXMLRegion):
 
     def __init__(self, doc_id: str = None, doc_type: Union[str, List[str]] = None,
                  metadata: Dict[str, any] = None, coords: Coords = None,
                  attrs: Dict[str, any] = None,
                  text_regions: List[PageXMLTextRegion] = None,
-                 table_regions: List[PageXMLTableRegion] = None,
                  lines: List[PageXMLTextLine] = None, text: str = None,
                  orientation: float = None, reading_order: Dict[int, str] = None,
                  reading_order_attributes: Dict[str, any] = None):
         super().__init__(doc_id=doc_id, doc_type="text_region", attrs=attrs, metadata=metadata,
-                         coords=coords, reading_order=reading_order,
-                         reading_order_attributes=reading_order_attributes, orientation=orientation)
+                         coords=coords, reading_order=reading_order, orientation=orientation,
+                         text_regions=text_regions,
+                         reading_order_attributes=reading_order_attributes)
         self.main_type = 'text_region'
-        self.text_regions: List[PageXMLTextRegion] = text_regions if text_regions is not None else []
-        self.table_regions: List[PageXMLTableRegion] = table_regions if table_regions is not None else []
-        for table in self.table_regions:
-            for row in table.rows:
-                if len(row) < table.num_columns:
-                    row.pad_columns(table.num_columns)
         self.lines: List[PageXMLTextLine] = lines if lines is not None else []
         self.reading_order_number = {}
         self.text = text
@@ -647,7 +843,7 @@ class PageXMLTextRegion(PageXMLDoc):
         if self.text_regions is not None:
             self.set_as_parent(self.text_regions)
         if self.reading_order:
-            self.set_text_regions_in_reader_order()
+            self.set_text_regions_in_reading_order()
         if doc_type:
             self.add_type(doc_type)
         self.empty_regions = []
@@ -656,17 +852,6 @@ class PageXMLTextRegion(PageXMLDoc):
         stats = json.dumps(self.stats)
         content_string = f"\n\tid={self.id}, \n\ttype={self.type}, \n\tstats={stats}"
         return f"{self.__class__.__name__}({content_string}\n)"
-
-    def __lt__(self, other: PageXMLTextRegion):
-        """For sorting text regions. Assumptions: reading from left to right,
-        top to bottom. If two regions are horizontally overlapping, sort from
-        top to bottom, even if the upper region is more horizontally indented."""
-        if other == self:
-            return False
-        if is_horizontally_overlapping(self, other):
-            return self.coords.top < other.coords.top
-        else:
-            return self.coords.left < other.coords.left
 
     def add_child(self, child: PageXMLDoc):
         child.set_parent(self)
@@ -682,7 +867,6 @@ class PageXMLTextRegion(PageXMLDoc):
     @property
     def children(self):
         child_elements: List[PageXMLDoc] = [tr for tr in self.text_regions]
-        child_elements.extend([tr for tr in self.table_regions])
         child_elements.extend([line for line in self.lines])
         return child_elements
 
@@ -693,87 +877,14 @@ class PageXMLTextRegion(PageXMLDoc):
             doc_json['text'] = self.text
         if self.lines:
             doc_json['lines'] = [line.json for line in self.lines]
-        if self.text_regions:
-            doc_json['text_regions'] = [text_region.json for text_region in self.text_regions]
-        if self.table_regions:
-            doc_json['table_regions'] = [table_region.json for table_region in self.table_regions]
-        if self.orientation:
-            doc_json['orientation'] = self.orientation
-        if self.reading_order_attributes:
-            doc_json['reading_order_attributes'] = self.reading_order_attributes
-        if self.reading_order:
-            doc_json['reading_order'] = self.reading_order
-        doc_json['stats'] = self.stats
         return doc_json
-
-    def get_text_regions_in_reading_order(self):
-        if not self.reading_order:
-            return self.text_regions
-        tr_ids = list({region_id: None for _index, region_id in sorted(self.reading_order.items(), key=lambda x: x[0])})
-        tr_map = {}
-        for text_region in self.text_regions:
-            # if text_region.id not in tr_ids:
-            #     print("reading order:", self.reading_order)
-            #     raise KeyError(f"text_region with id {text_region.id} is not listed in reading_order")
-            tr_map[text_region.id] = text_region
-        return [tr_map[tr_id] for tr_id in tr_ids if tr_id in tr_map]
-
-    def set_text_regions_in_reader_order(self):
-        tr_ids = [tr.id for tr in self.text_regions]
-        for order_number in self.reading_order:
-            text_region_id = self.reading_order[order_number]
-            self.reading_order_number[text_region_id] = order_number
-        for tr_id in tr_ids:
-            if tr_id not in self.reading_order_number:
-                # there is a text_region that was not in the original PageXML output:
-                # ignore reading order
-                self.reading_order = None
-                return None
-        self.text_regions = self.get_text_regions_in_reading_order()
-
-    def get_all_text_regions(self):
-        text_regions: Set[PageXMLTextRegion] = set()
-        for text_region in self.text_regions:
-            text_regions.add(text_region)
-            if text_region.text_regions:
-                text_regions += text_region.get_all_text_regions()
-        return text_regions
-
-    def get_inner_text_regions(self) -> List[PageXMLTextRegion]:
-        text_regions: List[PageXMLTextRegion] = []
-        for text_region in self.text_regions:
-            if text_region.text_regions:
-                text_regions += text_region.get_inner_text_regions()
-            elif text_region.lines:
-                text_regions.append(text_region)
-        if not self.text_regions and self.lines:
-            text_regions.append(self)
-        return text_regions
-
-    def get_table_regions(self):
-        table_regions = [tr for tr in self.table_regions]
-        for tr in self.text_regions:
-            table_regions.extend(tr.get_table_regions())
-        return table_regions
-
-    def get_regions(self, ignore_reading_order: bool = False) -> List[Union[PageXMLTextRegion, PageXMLTableRegion]]:
-        all_regions: List[PageXMLDoc] = [tr for tr in self.text_regions]
-        all_regions.extend(tr for tr in self.table_regions)
-        if self.reading_order and not ignore_reading_order:
-            ordered_regions = [tr for tr in all_regions if tr.id in self.reading_order]
-            unordered_regions = [tr for tr in all_regions if tr.id not in self.reading_order]
-        else:
-            ordered_regions = []
-            unordered_regions = all_regions
-        all_regions = sorted(ordered_regions, key=lambda t: self.reading_order_number[t.id])
-        all_regions.extend(unordered_regions)
-        return all_regions
 
     def get_lines(self, ignore_reading_order: bool = False) -> List[PageXMLTextLine]:
         lines: List[PageXMLTextLine] = []
         all_regions = self.get_regions(ignore_reading_order=ignore_reading_order)
         for tr in all_regions:
-            lines.extend(tr.get_lines())
+            if isinstance(tr, PageXMLTextRegion):
+                lines.extend(tr.get_lines())
         if self.lines:
             lines += self.lines
         return lines
@@ -802,14 +913,6 @@ class PageXMLTextRegion(PageXMLDoc):
         return sum(line.length for line in self.get_lines())
 
     @property
-    def num_text_regions(self):
-        return len(self.text_regions)
-
-    @property
-    def num_table_regions(self):
-        return len(self.get_table_regions())
-
-    @property
     def stats(self):
         stats = {
             'text_regions': self.num_text_regions,
@@ -836,20 +939,21 @@ class PageXMLTextRegion(PageXMLDoc):
         self.add_to_pagexml(page_xml)
 
 
-class PageXMLColumn(PageXMLTextRegion):
+class PageXMLColumn(PageXMLRegion):
 
     def __init__(self, doc_id: str = None, doc_type: Union[str, List[str]] = None,
                  metadata: Dict[str, any] = None, coords: Coords = None,
                  attrs: Dict[str, any] = None,
                  text_regions: List[PageXMLTextRegion] = None,
                  table_regions: List[PageXMLTableRegion] = None,
-                 lines: List[PageXMLTextLine] = None,
+                 empty_regions: List[PageXMLEmptyRegion] = None,
                  reading_order: Dict[int, str] = None,
                  reading_order_attributes: Dict[str, any] = None,
                  orientation: float = None):
         super().__init__(doc_id=doc_id, doc_type="column", attrs=attrs,
-                         metadata=metadata, coords=coords, lines=lines,
+                         metadata=metadata, coords=coords,
                          text_regions=text_regions, table_regions=table_regions,
+                         empty_regions=empty_regions,
                          orientation=orientation, reading_order=reading_order,
                          reading_order_attributes=reading_order_attributes)
         self.main_type = 'column'
@@ -864,10 +968,7 @@ class PageXMLColumn(PageXMLTextRegion):
 
     @property
     def children(self):
-        child_elements: List[PageXMLDoc] = [tr for tr in self.text_regions]
-        child_elements.extend([tr for tr in self.table_regions])
-        child_elements.extend([line for line in self.lines])
-        return child_elements
+        return self.regions
 
     @property
     def stats(self):
@@ -884,8 +985,15 @@ class PageXMLColumn(PageXMLTextRegion):
         for sub_tr in self.table_regions:
             sub_tr.add_to_pagexml(column_xml)
 
+    def _to_pagexml(self, page_xml: etree.Element):
+        self.add_to_pagexml(page_xml)
 
-class PageXMLPage(PageXMLTextRegion):
+
+def is_textual_region(region: PageXMLDoc):
+    return isinstance(region, PageXMLTextRegion) or isinstance(region, PageXMLTableRegion)
+
+
+class PageXMLPage(PageXMLRegion):
 
     def __init__(self, doc_id: str = None, doc_type: Union[str, List[str]] = None,
                  metadata: Dict[str, any] = None, coords: Coords = None,
@@ -893,36 +1001,40 @@ class PageXMLPage(PageXMLTextRegion):
                  columns: List[PageXMLColumn] = None,
                  text_regions: List[PageXMLTextRegion] = None,
                  table_regions: List[PageXMLTableRegion] = None,
-                 extra: List[PageXMLTextRegion] = None,
-                 lines: List[PageXMLTextLine] = None,
+                 empty_regions: List[PageXMLEmptyRegion] = None,
+                 extra: List[PageXMLRegion] = None,
                  orientation: float = None,
                  reading_order: Dict[int, str] = None,
                  reading_order_attributes: Dict[str, any] = None):
         super().__init__(doc_id=doc_id, doc_type="page", attrs=attrs,
-                         metadata=metadata, coords=coords, lines=lines,
+                         metadata=metadata, coords=coords,
                          text_regions=text_regions, table_regions=table_regions,
+                         empty_regions=empty_regions,
                          orientation=orientation, reading_order=reading_order,
                          reading_order_attributes=reading_order_attributes)
         self.main_type = 'page'
         self.columns: List[PageXMLColumn] = columns if columns else []
-        self.extra: List[PageXMLTextRegion] = extra if extra else []
+        self.extra: List[PageXMLRegion] = extra if extra else []
         self.set_as_parent(self.columns)
         self.set_as_parent(self.extra)
         if doc_type:
             self.add_type(doc_type)
+        if coords is None:
+            self.coords = parse_derived_coords(self.columns + self.regions + self.extra)
 
     def get_lines(self, ignore_reading_order: bool = False):
         lines = []
         # First, add lines from columns
         for column in sorted(self.columns):
-            lines += column.get_lines(ignore_reading_order=ignore_reading_order)
+            trs = column.regions
+            for tr in trs:
+                lines += tr.get_lines(ignore_reading_order=ignore_reading_order)
         # Second, add lines from text_regions
         all_regions = self.get_regions(ignore_reading_order=ignore_reading_order)
         all_regions.extend(self.extra)
         for tr in all_regions:
-            lines += tr.get_lines(ignore_reading_order=ignore_reading_order)
-        if self.lines:
-            raise AttributeError(f'page {self.id} has lines as direct property')
+            if isinstance(tr, PageXMLTextRegion) or isinstance(tr, PageXMLTableRegion):
+                lines += tr.get_lines()
         return lines
 
     def add_child(self, child: PageXMLDoc, as_extra: bool = False):
@@ -931,17 +1043,21 @@ class PageXMLPage(PageXMLTextRegion):
             self.extra.append(child)
         elif isinstance(child, PageXMLColumn) or child.__class__.__name__ == 'PageXMLColumn':
             self.columns.append(child)
-        elif isinstance(child, PageXMLTextLine):
-            self.lines.append(child)
         elif isinstance(child, PageXMLTextRegion):
             self.text_regions.append(child)
         else:
             raise TypeError(f'unknown child type: {child.__class__.__name__}')
-        derived_coords = parse_derived_coords([self] + self.extra + self.columns + self.text_regions + self.lines)
+        derived_coords = parse_derived_coords([self] + self.extra + self.columns + self.text_regions)
+        self.coords = derived_coords
 
-    def get_all_text_regions(self):
+    def get_textual_regions(self):
+        text_regions = [tr for col in self.columns for tr in col.get_textual_regions()]
+        text_regions.extend([r for r in self.extra if is_textual_region(r)])
+        return text_regions
+
+    def get_text_regions(self):
         text_regions = [tr for col in self.columns for tr in col.text_regions]
-        text_regions.extend([tr for tr in self.extra])
+        text_regions.extend([r for r in self.extra if isinstance(r, PageXMLTextRegion)])
         return text_regions
 
     def get_text_regions_in_reading_order(self, include_extra: bool = True):
@@ -994,7 +1110,7 @@ class PageXMLPage(PageXMLTextRegion):
         child_elements.extend([col for col in self.columns])
         child_elements.extend([tr for tr in self.text_regions])
         child_elements.extend([tr for tr in self.table_regions])
-        child_elements.extend([line for line in self.lines])
+        child_elements.extend([tr for tr in self.empty_regions])
         return child_elements
 
     @property
@@ -1010,12 +1126,14 @@ class PageXMLPage(PageXMLTextRegion):
         }
         if self.columns:
             stats['columns'] = len(self.columns)
+            stats['text_regions'] = sum(col.num_text_regions for col in self.columns)
+            stats['table_regions'] = sum(col.num_table_regions for col in self.columns)
         if self.extra:
             stats['extra'] = len(self.extra)
         if self.text_regions:
-            stats['text_regions'] = len(self.text_regions)
+            stats['text_regions'] += self.num_text_regions
         if self.table_regions:
-            stats['table_regions'] = len(self.get_table_regions())
+            stats['table_regions'] += self.num_table_regions
         return stats
 
     def add_to_pagexml(self, parent: etree.Element = None):
@@ -1032,8 +1150,11 @@ class PageXMLPage(PageXMLTextRegion):
         for tr in self.extra:
             tr.add_to_pagexml(page_xml)
 
+    def _to_pagexml(self, page_xml: etree.Element):
+        self.add_to_pagexml(page_xml)
 
-class PageXMLScan(PageXMLTextRegion):
+
+class PageXMLScan(PageXMLRegion):
 
     def __init__(self, doc_id: str = None, doc_type: Union[str, List[str]] = None,
                  metadata: Dict[str, any] = None, coords: Coords = None,
@@ -1041,14 +1162,12 @@ class PageXMLScan(PageXMLTextRegion):
                  pages: List[PageXMLPage] = None, columns: List[PageXMLColumn] = None,
                  text_regions: List[PageXMLTextRegion] = None,
                  table_regions: List[PageXMLTableRegion] = None,
-                 lines: List[PageXMLTextLine] = None,
                  orientation: float = None,
                  reading_order: Dict[int, str] = None,
                  reading_order_attributes: Dict[str, any] = None):
         super().__init__(doc_id=doc_id, doc_type="scan", attrs=attrs,
                          metadata=metadata, coords=coords,
                          text_regions=text_regions, table_regions=table_regions,
-                         lines=lines,
                          orientation=orientation, reading_order=reading_order,
                          reading_order_attributes=reading_order_attributes)
         self.main_type = 'scan'
@@ -1068,18 +1187,17 @@ class PageXMLScan(PageXMLTextRegion):
             self.columns.append(child)
         elif isinstance(child, PageXMLTextRegion):
             self.text_regions.append(child)
-        elif isinstance(child, PageXMLTextLine):
-            self.lines.append(child)
 
     def set_scan_id_as_metadata(self):
         self.metadata['scan_id'] = self.id
         for tr in self.get_all_text_regions():
             tr.metadata['scan_id'] = self.id
-        for line in self.get_lines():
-            line.metadata['scan_id'] = self.id
-        for word in self.get_words():
-            if isinstance(word, PageXMLWord):
-                word.metadata['scan_id'] = self.id
+        for region in self.regions:
+            for line in region.get_lines():
+                line.metadata['scan_id'] = self.id
+            for word in region.get_words():
+                if isinstance(word, PageXMLWord):
+                    word.metadata['scan_id'] = self.id
 
     @property
     def json(self) -> Dict[str, any]:
@@ -1102,6 +1220,7 @@ class PageXMLScan(PageXMLTextRegion):
         child_elements.extend([column for column in self.columns])
         child_elements.extend([tr for tr in self.text_regions])
         child_elements.extend([tr for tr in self.table_regions])
+        child_elements.extend([tr for tr in self.empty_regions])
         return child_elements
 
     @property
@@ -1153,14 +1272,24 @@ def has_baseline(doc: PhysicalStructureDoc):
         return False
 
 
-def get_horizontal_overlap(doc1: PageXMLDoc, doc2: PageXMLDoc) -> int:
+def get_horizontal_overlap(doc1: PageXMLDoc, doc2: PageXMLDoc, debug: int = 0) -> int:
+    if debug > 4:
+        dc1 = doc1.coords
+        dc2 = doc2.coords
+        print(f"doc1 - left: {dc1.left} right: {dc1.right} width: {dc1.width}")
+        print(f"doc2 - left: {dc2.left} right: {dc2.right} width: {dc2.width}")
+    if doc1.coords.width == 0:
+        return 1 if doc2.coords.left <= doc1.coords.left <= doc2.coords.right else 0
+    if doc2.coords.width == 0:
+        return 1 if doc1.coords.left <= doc2.coords.left <= doc1.coords.right else 0
     if has_baseline(doc1) and has_baseline(doc2):
-        overlap_left = max([doc1.baseline.left, doc2.baseline.left])
-        overlap_right = min([doc1.baseline.right, doc2.baseline.right])
+        max_left = max([doc1.baseline.left, doc2.baseline.left])
+        min_right = min([doc1.baseline.right, doc2.baseline.right])
     else:
-        overlap_left = max([doc1.coords.left, doc2.coords.left])
-        overlap_right = min([doc1.coords.right, doc2.coords.right])
-    return overlap_right - overlap_left + 1 if overlap_right >= overlap_left else 0
+        max_left = max([doc1.coords.left, doc2.coords.left])
+        min_right = min([doc1.coords.right, doc2.coords.right])
+    return max(0, min_right - max_left)
+    # return min_right - max_left + 1 if min_right >= max_left else 0
 
 
 def get_vertical_overlap(doc1: PageXMLDoc, doc2: PageXMLDoc) -> int:

--- a/pagexml/model/pagexml_document_model.py
+++ b/pagexml/model/pagexml_document_model.py
@@ -193,6 +193,11 @@ class PageXMLTextLine(PageXMLDoc):
         return sort_lines(self, other, as_column=True)
 
     @property
+    def text_height(self):
+        # Assume box cutout has top and bottom 25% around average character height
+        return self.xheight if self.xheight else self.coords.height / 2
+
+    @property
     def length(self):
         return len(self.text) if self.text is not None else 0
 
@@ -234,21 +239,28 @@ class PageXMLTextLine(PageXMLDoc):
     def num_words(self):
         return len(self.get_words())
 
-    def is_below(self, other: PageXMLTextLine) -> bool:
+    def is_below(self, other: PageXMLTextLine, direct_only: bool = True) -> bool:
         """Test if the baseline of this line is directly below the baseline of the other line."""
         # if there is no horizontal overlap, this line is not directly below the other
-        if not get_horizontal_overlap(self, other):
-            # print("NO HORIZONTAL OVERLAP")
+        if direct_only and not get_horizontal_overlap(self, other):
+            # print("pagexml.pdm - NO HORIZONTAL OVERLAP")
             return False
+        if not direct_only and not get_horizontal_overlap(self, other):
+            vertical_overlap = get_vertical_overlap(self, other)
+            min_height = min(self.text_height, other.text_height)
+            if vertical_overlap / min_height > 0.5:
+                # print("pagexml.pdm - NO HORIZONTAL OVERLAP, LINES VERTICALLY OVERLAP")
+                return False
         # if the bottom of this line is above the top of the other line, this line is above the other
         if self.baseline.bottom < other.baseline.top:
-            # print("BOTTOM IS ABOVE TOP")
+            # print("pagexml.pdm - BOTTOM OF SELF IS ABOVE TOP OF OTHER")
             return False
         # if most of this line's baseline points are not below most the other's baseline points
         # this line is not below the other
         if baseline_is_below(self.baseline, other.baseline):
-            # print("BASELINE IS BELOW")
+            # print("pagexml.pdm - BASELINE OF SELF IS BELOW BASELINE OF OTHER")
             return True
+        # print("pagexml.pdm - SELF IS ADJACENT TO OTHER")
         return False
 
     def is_next_to(self, other: PageXMLTextLine) -> bool:
@@ -1242,6 +1254,9 @@ class PageXMLScan(PageXMLRegion):
         for sub_tr in self.table_regions:
             sub_tr.add_to_pagexml(scan_xml)
 
+    def _to_pagexml(self, page_xml: etree.Element):
+        self.add_to_pagexml(page_xml)
+
 
 def sort_lines(line1: PageXMLTextLine, line2: PageXMLTextLine, as_column: bool = True):
     if get_horizontal_overlap(line1, line2):
@@ -1292,9 +1307,31 @@ def get_horizontal_overlap(doc1: PageXMLDoc, doc2: PageXMLDoc, debug: int = 0) -
     # return min_right - max_left + 1 if min_right >= max_left else 0
 
 
+def get_line_top_bottom(line: PageXMLTextLine):
+    if has_baseline(line):
+        line_bottom = line.baseline.bottom
+        line_height = line.xheight if line.xheight else int(line.coords.height / 2)
+        line_top = line.baseline.top - line_height
+    else:
+        # assume the box cut around a line has 25% of its height below
+        # the baseline
+        line_bottom = line.coords.bottom - line.coords.height * 0.25
+        line_top = line.coords.top + line.coords.height * 0.25
+    return line_top, line_bottom
+
+
 def get_vertical_overlap(doc1: PageXMLDoc, doc2: PageXMLDoc) -> int:
-    overlap_top = max([doc1.coords.top, doc2.coords.top])
-    overlap_bottom = min([doc1.coords.bottom, doc2.coords.bottom])
+    if doc1.coords.height == 0:
+        return 1 if doc2.coords.top <= doc1.coords.top <= doc2.coords.bottom else 0
+    if doc2.coords.height == 0:
+        return 1 if doc1.coords.top <= doc2.coords.top <= doc1.coords.bottom else 0
+    if isinstance(doc1, PageXMLTextLine) and isinstance(doc2, PageXMLTextLine):
+        doc1_top, doc1_bottom = get_line_top_bottom(doc1)
+        doc2_top, doc2_bottom = get_line_top_bottom(doc2)
+        return min(doc1_bottom, doc2_bottom) - max(doc1_top, doc2_top)
+    else:
+        overlap_top = max([doc1.coords.top, doc2.coords.top])
+        overlap_bottom = min([doc1.coords.bottom, doc2.coords.bottom])
     return overlap_bottom - overlap_top + 1 if overlap_bottom >= overlap_top else 0
 
 

--- a/pagexml/model/pagexml_document_model.py
+++ b/pagexml/model/pagexml_document_model.py
@@ -333,7 +333,8 @@ class PageXMLRegion(PageXMLDoc):
             for row in table.rows:
                 if len(row) < table.num_columns:
                     row.pad_columns(table.num_columns)
-        for region in self.regions:
+        regions = self.text_regions + self.table_regions + self.empty_regions
+        for region in regions:
             region.set_parent(self)
 
     def __repr__(self):

--- a/pagexml/model/pagexml_document_model.py
+++ b/pagexml/model/pagexml_document_model.py
@@ -1074,6 +1074,12 @@ class PageXMLPage(PageXMLRegion):
         derived_coords = parse_derived_coords([self] + self.extra + self.columns + self.text_regions)
         self.coords = derived_coords
 
+    @property
+    def regions(self):
+        regions = [region for col in self.columns for region in col.get_regions()]
+        regions.extend(region for region in self.extra)
+        return sorted(regions)
+
     def get_textual_regions(self):
         text_regions = [tr for col in self.columns for tr in col.get_textual_regions()]
         text_regions.extend([r for r in self.extra if is_textual_region(r)])

--- a/pagexml/model/physical_document_model.py
+++ b/pagexml/model/physical_document_model.py
@@ -3,12 +3,13 @@ from collections import namedtuple
 
 from typing import List, Union
 
-from pagexml.model.coords import Baseline, Coords, parse_derived_coords
+from pagexml.model.coords import Point, Baseline, Coords, parse_derived_coords, coords_as_span
 from pagexml.model.basic_document_model import StructureDoc, PhysicalStructureDoc
-from pagexml.model.pagexml_document_model import PageXMLDoc, PageXMLTextLine, PageXMLTextRegion
+from pagexml.model.pagexml_document_model import PageXMLDoc, PageXMLRegion, PageXMLEmptyRegion
+from pagexml.model.pagexml_document_model import PageXMLTextLine, PageXMLTextRegion
 from pagexml.model.pagexml_document_model import PageXMLTableRegion, PageXMLTableRow, PageXMLTableCell
 from pagexml.model.pagexml_document_model import get_horizontal_overlap, get_vertical_overlap
-from pagexml.model.pagexml_document_model import sort_lines
+from pagexml.model.pagexml_document_model import sort_lines, CHILD_PROPERTIES
 from pagexml.model.pagexml_document_model import is_vertically_overlapping, is_horizontally_overlapping
 from pagexml.model.pagexml_document_model import get_vertical_diff, get_horizontal_diff
 from pagexml.model.pagexml_document_model import get_vertical_diff_ratio, get_horizontal_diff_ratio
@@ -19,7 +20,7 @@ Interval = namedtuple('Interval', ['type', 'start', 'end'])
 
 
 def within_interval(doc: PageXMLDoc, interval: Interval,
-                 overlap_threshold: float = 0.5):
+                    overlap_threshold: float = 0.5):
     start = max([doc.coords.left, interval.start])
     end = min([doc.coords.right, interval.end])
     overlap = end - start if end > start else 0
@@ -51,28 +52,11 @@ def combine_doc_types(doc_type1: Union[str, List[str], None],
 
 
 def set_parentage(parent_doc: StructureDoc):
-    if isinstance(parent_doc, PageXMLScan) or hasattr(parent_doc, 'pages') and parent_doc.pages:
-        parent_doc.set_as_parent(parent_doc.pages)
-        for page in parent_doc.pages:
-            set_parentage(page)
-    if isinstance(parent_doc, PageXMLPage) or hasattr(parent_doc, 'columns') and parent_doc.columns:
-        parent_doc.set_as_parent(parent_doc.columns)
-        for column in parent_doc.columns:
-            set_parentage(column)
-    if isinstance(parent_doc, PageXMLColumn) or hasattr(parent_doc, 'text_regions') and parent_doc.text_regions:
-        parent_doc.set_as_parent(parent_doc.text_regions)
-        for text_region in parent_doc.text_regions:
-            set_parentage(text_region)
-    if hasattr(parent_doc, 'lines') and parent_doc.lines:
-        parent_doc.set_as_parent(parent_doc.lines)
-        for line in parent_doc.lines:
-            set_parentage(line)
-    if hasattr(parent_doc, 'words') and parent_doc.words:
-        parent_doc.set_as_parent(parent_doc.words)
-        for word in parent_doc.words:
-            set_parentage(word)
-    if isinstance(parent_doc, PageXMLWord):
-        pass
+    for child_property in CHILD_PROPERTIES:
+        if hasattr(parent_doc, child_property) and parent_doc.__getattribute__(child_property):
+            parent_doc.set_as_parent(parent_doc.__getattribute__(child_property))
+            for child in parent_doc.__getattribute__(child_property):
+                set_parentage(child)
 
 
 def in_same_column(element1: PageXMLDoc, element2: PageXMLDoc) -> bool:

--- a/pagexml/model/physical_document_model.py
+++ b/pagexml/model/physical_document_model.py
@@ -106,6 +106,7 @@ def vertical_distance(doc1: PageXMLDoc, doc2: PageXMLDoc):
     if hasattr(doc1, 'baseline') and hasattr(doc2, 'baseline'):
         doc1_top, doc1_bottom = get_line_top_bottom(doc1)
         doc2_top, doc2_bottom = get_line_top_bottom(doc2)
+        return abs(doc1_bottom - doc2_bottom)
     else:
         doc1_top, doc1_bottom = doc1.coords.top, doc1.coords.bottom
         doc2_top, doc2_bottom = doc2.coords.top, doc2.coords.bottom

--- a/pagexml/model/physical_document_model.py
+++ b/pagexml/model/physical_document_model.py
@@ -9,6 +9,7 @@ from pagexml.model.pagexml_document_model import PageXMLDoc, PageXMLRegion, Page
 from pagexml.model.pagexml_document_model import PageXMLTextLine, PageXMLTextRegion
 from pagexml.model.pagexml_document_model import PageXMLTableRegion, PageXMLTableRow, PageXMLTableCell
 from pagexml.model.pagexml_document_model import get_horizontal_overlap, get_vertical_overlap
+from pagexml.model.pagexml_document_model import get_line_top_bottom
 from pagexml.model.pagexml_document_model import has_baseline, sort_lines, CHILD_PROPERTIES
 from pagexml.model.pagexml_document_model import is_vertically_overlapping, is_horizontally_overlapping
 from pagexml.model.pagexml_document_model import get_vertical_diff, get_horizontal_diff
@@ -102,12 +103,18 @@ def horizontal_distance(doc1: PageXMLDoc, doc2: PageXMLDoc):
 
 
 def vertical_distance(doc1: PageXMLDoc, doc2: PageXMLDoc):
-    if doc1.coords.bottom < doc2.coords.top:
+    if hasattr(doc1, 'baseline') and hasattr(doc2, 'baseline'):
+        doc1_top, doc1_bottom = get_line_top_bottom(doc1)
+        doc2_top, doc2_bottom = get_line_top_bottom(doc2)
+    else:
+        doc1_top, doc1_bottom = doc1.coords.top, doc1.coords.bottom
+        doc2_top, doc2_bottom = doc2.coords.top, doc2.coords.bottom
+    if doc1_bottom < doc2_top:
         # doc1 is above doc2
-        return doc2.coords.top - doc1.coords.bottom
-    elif doc1.coords.top > doc2.coords.bottom:
+        return doc2_top - doc1_bottom
+    elif doc1_top > doc2_bottom:
         # doc1 is below doc2
-        return doc1.coords.top - doc2.coords.bottom
+        return doc1_top - doc2_bottom
     else:
         # doc1 and doc2 vertically overlap
         return 0

--- a/pagexml/model/physical_document_model.py
+++ b/pagexml/model/physical_document_model.py
@@ -9,7 +9,7 @@ from pagexml.model.pagexml_document_model import PageXMLDoc, PageXMLRegion, Page
 from pagexml.model.pagexml_document_model import PageXMLTextLine, PageXMLTextRegion
 from pagexml.model.pagexml_document_model import PageXMLTableRegion, PageXMLTableRow, PageXMLTableCell
 from pagexml.model.pagexml_document_model import get_horizontal_overlap, get_vertical_overlap
-from pagexml.model.pagexml_document_model import sort_lines, CHILD_PROPERTIES
+from pagexml.model.pagexml_document_model import has_baseline, sort_lines, CHILD_PROPERTIES
 from pagexml.model.pagexml_document_model import is_vertically_overlapping, is_horizontally_overlapping
 from pagexml.model.pagexml_document_model import get_vertical_diff, get_horizontal_diff
 from pagexml.model.pagexml_document_model import get_vertical_diff_ratio, get_horizontal_diff_ratio
@@ -73,13 +73,6 @@ def in_same_column(element1: PageXMLDoc, element2: PageXMLDoc) -> bool:
         # check if the two lines have a horizontal overlap that is more than 50% of the width of line 1
         # Note: this doesn't work for short adjacent lines within the same column
         return get_horizontal_overlap(element1, element2) > (element1.coords.w / 2)
-
-
-def has_baseline(doc: PageXMLDoc) -> bool:
-    if isinstance(doc, PageXMLTextLine):
-        return doc.baseline is not None
-    else:
-        return False
 
 
 def is_below(region1: PageXMLTextRegion, region2: PageXMLTextRegion, margin: int = 20) -> bool:

--- a/pagexml/model/xml.py
+++ b/pagexml/model/xml.py
@@ -80,7 +80,16 @@ def make_custom_string(custom):
     element_strings = []
     for custom_element in custom:
         tag_fields = [field for field in custom_element if field != 'tag_name']
-        tag_string = ' '.join([f"{field}:{custom_element[field]};" for field in tag_fields])
+        # tag_string = ' '.join([f"{field}:{custom_element[field]};" for field in tag_fields])
+        field_strings = []
+        # Update 2025-12-23: allow for fields that have no value, e.g. `strikethrough`
+        for field in tag_fields:
+            if custom_element[field] is True:
+                field_string = field
+            else:
+                field_string = f"{field}:{custom_element[field]}"
+            field_strings.append(field_string)
+        tag_string = '; '.join(field_strings)
         element_string = custom_element['tag_name'] + ' {' + tag_string + '} '
         element_strings.append(element_string)
 

--- a/pagexml/parser.py
+++ b/pagexml/parser.py
@@ -248,7 +248,7 @@ def parse_textregion(text_region_dict: dict,
             text_region.text = parse_text_equiv(text_region_dict[child])
         if child == 'TextLine':
             text_region.lines = parse_textline_list(text_region_dict['TextLine'], custom_tags)
-            text_region.set_as_parent(text_region.lines)
+            # text_region.set_as_parent(text_region.lines)
             if not text_region.coords:
                 text_region.coords = parse_derived_coords(text_region.lines)
         if child == 'TextRegion':
@@ -258,7 +258,7 @@ def parse_textregion(text_region_dict: dict,
             for tr in parse_textregion_list(text_region_dict['TextRegion'], custom_tags):
                 if tr is not None:
                     text_region.text_regions.append(tr)
-            text_region.set_as_parent(text_region.text_regions)
+            # text_region.set_as_parent(text_region.text_regions)
             if not text_region.coords:
                 text_region.coords = parse_derived_coords(text_region.text_regions)
     if text_region.coords is None:
@@ -291,6 +291,7 @@ def parse_table_cell(table_cell_dict: Dict[str, any], custom_tags: Iterable = No
         cornerpoints=parse_corner_points(table_cell_dict['CornerPts']) if 'CornerPts' in table_cell_dict else None,
         lines=lines
     )
+    # table_cell.set_as_parent(table_cell.lines)
     return table_cell
 
 
@@ -329,7 +330,7 @@ def parse_tableregion(table_region_dict, custom_tags: Iterable = None):
                 cell = parse_table_cell(table_cell_dict, custom_tags)
                 cells.append(cell)
     table_region.rows = make_rows_from_cells(cells)
-    table_region.set_as_parent(table_region.rows)
+    # table_region.set_as_parent(table_region.rows)
     return table_region
 
 
@@ -341,7 +342,7 @@ def make_rows_from_cells(cells: List[pdm.PageXMLTableCell]) -> List[pdm.PageXMLT
     for row_id in row_cells:
         row_coords = parse_derived_coords(row_cells[row_id])
         table_row = pdm.PageXMLTableRow(doc_id=row_id, coords=row_coords, cells=row_cells[row_id])
-        table_row.set_as_parent(table_row.cells)
+        # table_row.set_as_parent(table_row.cells)
         rows.append(table_row)
     return rows
 
@@ -452,6 +453,7 @@ def parse_pagexml_json(pagexml_file: str, scan_json: dict, custom_tags: Iterable
         reading_order=reading_order,
         reading_order_attributes=reading_order_attributes
     )
+    pdm.set_parentage(scan_doc)
     return scan_doc
 
 
@@ -518,7 +520,7 @@ def read_pagexml_dirs(pagexml_dirs: Union[str, List[str]]) -> List[str]:
     return pagexml_files
 
 
-def parse_pagexml_files_from_directory(pagexml_directories: List[str],
+def parse_pagexml_files_from_directory(pagexml_directories: Union[str, List[str]],
                                        show_progress: bool = False) -> Generator[pdm.PageXMLScan, None, None]:
     """Parse PageXML files from one or more directories.
 
@@ -694,8 +696,7 @@ def json_to_pagexml_column(json_doc: dict) -> pdm.PageXMLColumn:
                                attrs=json_doc['attributes'] if 'attributes' in json_doc else None,
                                coords=pdm.Coords(json_doc['coords']), orientation=orientation,
                                reading_order=reading_order, reading_order_attributes=reading_order_attributes,
-                               text_regions=text_regions, table_regions=table_regions,
-                               lines=lines)
+                               text_regions=text_regions, table_regions=table_regions)
     pdm.set_parentage(column)
     return column
 
@@ -715,7 +716,7 @@ def json_to_pagexml_page(json_doc: dict) -> pdm.PageXMLPage:
     page = pdm.PageXMLPage(doc_id=json_doc['id'], doc_type=json_doc['type'], metadata=json_doc['metadata'],
                            attrs=json_doc['attributes'] if 'attributes' in json_doc else None,
                            coords=coords, extra=extra, columns=columns,
-                           text_regions=text_regions, table_regions=table_regions, lines=lines,
+                           text_regions=text_regions, table_regions=table_regions,
                            orientation=orientation, reading_order=reading_order,
                            reading_order_attributes=reading_order_attributes)
     pdm.set_parentage(page)
@@ -729,7 +730,7 @@ def json_to_pagexml_scan(json_doc: dict) -> pdm.PageXMLScan:
     scan = pdm.PageXMLScan(doc_id=json_doc['id'], doc_type=json_doc['type'], metadata=json_doc['metadata'],
                            attrs=json_doc['attributes'] if 'attributes' in json_doc else None,
                            coords=coords, pages=pages, columns=columns,
-                           text_regions=text_regions, table_regions=table_regions, lines=lines,
+                           text_regions=text_regions, table_regions=table_regions,
                            orientation=orientation, reading_order=reading_order,
                            reading_order_attributes=reading_order_attributes)
     pdm.set_parentage(scan)
@@ -737,8 +738,8 @@ def json_to_pagexml_scan(json_doc: dict) -> pdm.PageXMLScan:
 
 
 def json_to_pagexml_doc(json_doc: dict) -> pdm.PageXMLDoc:
-    if 'pagexml_doc' not in json_doc['type']:
-        raise TypeError('json_doc is not of type "pagexml_doc".')
+    # if 'pagexml_doc' not in json_doc['type']:
+    #     raise TypeError('json_doc is not of type "pagexml_doc".')
     if 'scan' in json_doc['type']:
         return json_to_pagexml_scan(json_doc)
     if 'page' in json_doc['type']:

--- a/pagexml/parser.py
+++ b/pagexml/parser.py
@@ -147,7 +147,12 @@ def parse_custom_metadata_element_list(custom_string: str, custom_field: str) ->
 
     for match in matches:
         tag = match.group(1)
-        metadata = parse_custom_attribute_parts(match.group(2))
+        try:
+            metadata = parse_custom_attribute_parts(match.group(2))
+        except ValueError:
+            print(f"Error parsing the following field in custom attribute string and re match:"
+                  f"\n\tFIELD: {custom_field}\n\t{custom_string}\n\t{match}")
+            raise
         metadata['type'] = tag
         metadata_list.append(metadata)
 
@@ -160,7 +165,11 @@ def parse_custom_attributes(custom_string: str) -> List[Dict[str, any]]:
     matches = re.finditer(r'\b(\w+) {(.*?)}', custom_string)
     custom_attributes = []
     for match in matches:
-        attribute = parse_custom_attribute_parts(match.group(2))
+        try:
+            attribute = parse_custom_attribute_parts(match.group(2))
+        except ValueError:
+            print(f"Error parsing the following custom attribute string and re match:\n\t{custom_string}\n\t{match}")
+            raise
         attribute['tag_name'] = match.group(1)
         custom_attributes.append(attribute)
     return custom_attributes
@@ -169,12 +178,15 @@ def parse_custom_attributes(custom_string: str) -> List[Dict[str, any]]:
 def parse_custom_attribute_parts(attribute_string: str) -> Dict[str, any]:
     """Parse the string of custom attributes into a dictionary.
 
+    Examples:
+        `offset:0; length:2;strikethrough`
     Assumptions:
 
     1. attributes are always and only separated by semicolons (;)
     2. attribute key/value pairs are always separated by a colon (:)
-    3. there is no nesting of attributes. The attributes are a flat list
-    4. attribute values contain only alphanumeric characters, no punctuation
+    3. there can be valueless attributes (e.g. `strikethrough`)
+    4. there is no nesting of attributes. The attributes are a flat list
+    5. attribute values contain only alphanumeric characters, no punctuation
        or quotes, whitespace other symbols
     """
     structure_parts = attribute_string.strip().split(';')
@@ -182,10 +194,12 @@ def parse_custom_attribute_parts(attribute_string: str) -> Dict[str, any]:
     for part in structure_parts:
         if part == '':
             continue
-        field, value = part.split(':')
-
-        field = field.strip()
-        value = value.strip()
+        if ':' in part:
+            field, value = part.split(':')
+            field = field.strip()
+            value = value.strip()
+        else:
+            field, value = part, True
 
         if field in ('offset', 'length', 'index'):
             metadata[field] = int(value)

--- a/pagexml/parsers/column_parser.py
+++ b/pagexml/parsers/column_parser.py
@@ -1,12 +1,16 @@
 import copy
-from typing import  List
+from typing import Iterable, List, Union
 from collections import Counter
 
+import pagexml.helper.pagexml_helper as pagexml_helper
 import pagexml.model.physical_document_model as pdm
 
 
-def compute_text_pixel_dist(lines: List[pdm.PageXMLTextLine]) -> Counter:
-    """Count how many lines are above each horizontal pixel coordinate."""
+def compute_text_pixel_dist(lines: List[pdm.PageXMLTextLine],
+                            use_height: bool = False) -> Counter:
+    """Count how many lines are above each horizontal pixel coordinate.
+    Use `use_height` to use the height of lines in pixels instead of the
+    number of lines."""
     pixel_dist = Counter()
     for line in lines:
         if line.coords is None and line.baseline is None:
@@ -20,7 +24,16 @@ def compute_text_pixel_dist(lines: List[pdm.PageXMLTextLine]) -> Counter:
                 left = line.coords.left
             if right is None or line.baseline.right > right:
                 right = line.coords.right
-        pixel_dist.update([pixel for pixel in range(left, right + 1)])
+        if use_height is True:
+            for pixel in range(left, right + 1):
+                if line.xheight:
+                    height = line.xheight
+                else:
+                    # bounding box usually is cut out quite generously
+                    height = line.coords.height / 2
+                pixel_dist[pixel] += height
+        else:
+            pixel_dist.update([pixel for pixel in range(left, right + 1)])
     return pixel_dist
 
 
@@ -67,23 +80,6 @@ def find_column_ranges(lines: List[pdm.PageXMLTextLine], min_column_lines: int =
     return column_ranges
 
 
-def find_column_gaps(lines: List[pdm.PageXMLTextLine],
-                     min_column_lines: int = 2, min_gap_width: int = 20,
-                     min_column_width: int = 20, debug: int = 0):
-    column_ranges = find_column_ranges(lines, min_column_lines=min_column_lines,
-                                       min_gap_width=min_gap_width, min_column_width=min_column_width,
-                                       debug=debug)
-    if len(column_ranges) < 2:
-        return []
-    gap_ranges = []
-    for ci, curr_range in enumerate(column_ranges[:-1]):
-        next_range = column_ranges[ci+1]
-        if next_range.start - curr_range.end >= min_gap_width:
-            gap_range = pdm.Interval('text_pixel', start=curr_range.end, end=next_range.start)
-            gap_ranges.append(gap_range)
-    return gap_ranges
-
-
 def find_overlapping_columns(columns: List[pdm.PageXMLColumn]):
     columns.sort()
     merge_sets = []
@@ -99,36 +95,23 @@ def find_overlapping_columns(columns: List[pdm.PageXMLColumn]):
     return merge_sets
 
 
-def merge_columns(columns: List[pdm.PageXMLColumn],
-                  doc_id: str, metadata: dict, lines_only: bool = False) -> pdm.PageXMLColumn:
+def merge_columns(columns: List[pdm.PageXMLColumn], doc_id: str, metadata: dict,
+                  lines_only: bool = False, debug: int = 0) -> pdm.PageXMLColumn:
     """Merge two columns into one, sorting lines by baseline height."""
     if lines_only is True:
         merged_lines = [line for col in columns for line in col.get_lines()]
         merged_lines = list(set(merged_lines))
         sorted_lines = sorted(merged_lines, key=lambda x: x.baseline.y)
-        merged_coords = pdm.parse_derived_coords(sorted_lines)
-        merged_col = pdm.PageXMLColumn(doc_id=doc_id,
-                                       metadata=metadata, coords=merged_coords,
-                                       lines=merged_lines)
+        tr = pagexml_helper.derive_text_region_from_lines(sorted_lines)
+        merged_col = derive_column_from_regions(tr, debug=debug)
     else:
         merged_trs = [tr for col in columns for tr in col.text_regions]
         sorted_trs = sorted(merged_trs, key=lambda x: x.coords.y)
-        merged_lines = [line for col in columns for line in col.lines]
-        sorted_lines = sorted(merged_lines, key=lambda x: x.baseline.y)
-        try:
-            merged_coords = pdm.parse_derived_coords(sorted_trs + sorted_lines)
-        except IndexError:
-            print(f"pagexml_helper.merge_column - Error deriving coords from trs and lines:")
-            print(f"    number of trs: {len(sorted_trs)}")
-            print(f"    number of lines: {len(sorted_lines)}")
-            for tr in sorted_trs:
-                print(f"\ttr {tr.id}\tnumber of points: {len(tr.coords.points)}")
-            for line in sorted_lines:
-                print(f"\tline {line.id}\tnumber of points: {len(line.coords.points)}")
-            raise
-        merged_col = pdm.PageXMLColumn(doc_id=doc_id,
-                                       metadata=metadata, coords=merged_coords,
-                                       text_regions=sorted_trs, lines=sorted_lines)
+        merged_col = derive_column_from_regions(sorted_trs, debug=debug)
+    if doc_id:
+        merged_col.doc_id = doc_id
+    if metadata:
+        merged_col.metadata = metadata
 
     for col in columns:
         for col_type in col.types:
@@ -138,6 +121,8 @@ def merge_columns(columns: List[pdm.PageXMLColumn],
 
 
 def add_line_to_column(line: pdm.PageXMLTextLine, column: pdm.PageXMLColumn) -> None:
+    """Add a PageXMLTextLine to a PageXMLColumn, assign to the appropriate text region
+    or create a new text region for it."""
     for tr in column.text_regions:
         if pdm.is_horizontally_overlapping(line, tr, threshold=0.1) and \
                 pdm.is_vertically_overlapping(line, tr, threshold=0.1):
@@ -154,21 +139,10 @@ def add_line_to_column(line: pdm.PageXMLTextLine, column: pdm.PageXMLColumn) -> 
     column.text_regions.sort()
 
 
-def split_lines_on_column_gaps(text_region: pdm.PageXMLTextRegion,
-                               min_column_lines: int = 2,
-                               min_gap_width: int = 20,
-                               min_column_width: int = 20,
-                               overlap_threshold: float = 0.5,
-                               ignore_bad_coordinate_lines: bool = True,
-                               debug: int = 0) -> List[pdm.PageXMLColumn]:
-    lines = [line for line in text_region.get_lines()]
-    if 'scan_id' not in text_region.metadata:
-        raise KeyError(f'no "scan_id" in text_region {text_region.id}')
-    column_ranges = find_column_ranges(lines, min_column_lines=min_column_lines, min_gap_width=min_gap_width,
-                                       min_column_width=min_column_width, debug=debug-1)
-    if debug > 0:
-        print('split_lines_on_column_gaps - text_region:', text_region.id, text_region.stats)
-        print("COLUMN RANGES:", column_ranges)
+def sort_lines_on_column_ranges(text_region: pdm.PageXMLTextRegion, lines: List[pdm.PageXMLTextLine],
+                                column_ranges: List[pdm.Interval], overlap_threshold: float,
+                                debug: int = 0):
+    """Map each line of a set of lines to the corresponding horizontally overlapping column range."""
     column_lines = [[] for _ in range(len(column_ranges))]
     extra_lines = []
     num_lines = text_region.stats['lines']
@@ -189,12 +163,78 @@ def split_lines_on_column_gaps(text_region: pdm.PageXMLTextRegion,
             extra_lines.append(line)
             append_count += 1
             # print(f"APPENDING EXTRA LINE: {line.coords.left}-{line.coords.right}\t{line.coords.y}\t{line.text}")
-    columns = []
     if debug > 0:
         print('RANGE SPLIT num_lines:', num_lines, 'append_count:', append_count)
         for ci, lines in enumerate(column_lines):
             print('\tcolumn', ci, '\tlines:', len(lines))
         print('\textra lines:', len(extra_lines))
+    return column_lines, extra_lines
+
+
+def derive_column_from_regions(regions: Union[pdm.PageXMLRegion, List[pdm.PageXMLRegion]],
+                               debug: int = 0):
+    text_regions, table_regions, empty_regions = [], [], []
+    if isinstance(regions, Iterable) is False:
+        regions = [regions]
+    for region in regions:
+        if isinstance(region, pdm.PageXMLTextRegion):
+            text_regions.append(pagexml_helper.copy_text_region(region))
+        elif isinstance(region, pdm.PageXMLTableRegion):
+            table_regions.append(pagexml_helper.copy_table_region(region))
+        elif isinstance(region, pdm.PageXMLEmptyRegion):
+            empty_regions.append(pagexml_helper.copy_empty_region(region))
+        else:
+            print(f"column_parser.derive_column_from_regions - region: {region.id} {region.__class__.__name__}")
+            raise ValueError(f"Generating a column from a generic PageXMLRegion is not implemented. "
+                             f"Please use PageXMLTextRegion, PageXMLTableRegion or PagexmlEmptyRegion "
+                             f"instead.")
+    if debug > 0:
+        print(f"derive_column_from_regions - region ids: {[r.id for r in regions]}")
+    try:
+        coords = pdm.parse_derived_coords(regions)
+    except BaseException as err:
+        for region in regions:
+            print(region.coords.box_string)
+        raise
+    column = pdm.PageXMLColumn(metadata=copy.deepcopy(regions[0].metadata),
+                               coords=coords, text_regions=text_regions,
+                               table_regions=table_regions, empty_regions=empty_regions)
+    if regions[0].parent:
+        column.set_parent(regions[0].parent)
+    if regions[0].parent and regions[0].parent.id:
+        column.set_derived_id(regions[0].parent.id)
+    else:
+        column.set_derived_id(regions[0].id)
+    column.set_as_parent(column.regions)
+    return column
+
+
+def normalise_columns(columns: List[pdm.PageXMLColumn], debug: int = 0) -> List[pdm.PageXMLColumn]:
+    """Normalise a list of columns by merging columns with horizontal overlap."""
+    merge_sets = find_overlapping_columns(columns)
+    merge_cols = {col for merge_set in merge_sets for col in merge_set}
+    non_overlapping_cols = [col for col in columns if col not in merge_cols]
+    for merge_set in merge_sets:
+        if debug > 0:
+            print("MERGING OVERLAPPING COLUMNS:", [col.id for col in merge_set])
+        first_col = merge_set[0]
+        merged_col = merge_columns(merge_set, "temp_id", first_col.metadata)
+        if first_col.parent:
+            merged_col.set_parent(first_col.parent)
+        if first_col.parent and first_col.parent.id:
+            merged_col.set_derived_id(first_col.parent.id)
+        else:
+            merged_col.set_derived_id(first_col.id)
+        non_overlapping_cols.append(merged_col)
+    columns = non_overlapping_cols
+    return sorted(columns)
+
+
+def derive_column_from_lines(text_region: pdm.PageXMLTextRegion,
+                             column_lines: List[List[pdm.PageXMLTextLine]],
+                             debug: int = 0) -> List[pdm.PageXMLColumn]:
+    """Generate PageXMLColumn instances per set of horizontally grouped lines."""
+    columns = []
     for lines in column_lines:
         if len(lines) == 0:
             continue
@@ -204,33 +244,18 @@ def split_lines_on_column_gaps(text_region: pdm.PageXMLTextRegion,
                                    coords=copy.deepcopy(coords), lines=lines)
         tr.set_derived_id(text_region.metadata['scan_id'])
         tr.set_as_parent(lines)
-        column = pdm.PageXMLColumn(doc_type=copy.deepcopy(text_region.type),
-                                   metadata=copy.deepcopy(text_region.metadata),
-                                   coords=copy.deepcopy(coords), text_regions=[tr])
-        if text_region.parent and text_region.parent.id:
-            column.set_derived_id(text_region.parent.id)
-            column.set_parent(text_region.parent)
-        else:
-            column.set_derived_id(text_region.id)
-        column.set_as_parent(column.text_regions)
+        column = derive_column_from_regions(tr, debug=debug)
         columns.append(column)
     # column range may have expanded with lines partially overlapping initial range
+    return columns
+
+
+def add_extra_lines_to_columns(text_region: pdm.PageXMLTextRegion, columns: List[pdm.PageXMLColumn],
+                               extra_lines: List[pdm.PageXMLTextLine], debug: int = 0):
+    """"Assign extra lines not yet belonging to any column to its overlapping column, returning
+    any lines that do not overlap with any column."""
     # check which extra lines should be added to columns
     non_col_lines = []
-    merge_sets = find_overlapping_columns(columns)
-    merge_cols = {col for merge_set in merge_sets for col in merge_set}
-    non_overlapping_cols = [col for col in columns if col not in merge_cols]
-    for merge_set in merge_sets:
-        if debug > 0:
-            print("MERGING OVERLAPPING COLUMNS:", [col.id for col in merge_set])
-        merged_col = merge_columns(merge_set, "temp_id", merge_set[0].metadata)
-        if text_region.parent and text_region.parent.id:
-            merged_col.set_derived_id(text_region.parent.id)
-            merged_col.set_parent(text_region.parent)
-        else:
-            merged_col.set_derived_id(text_region.id)
-        non_overlapping_cols.append(merged_col)
-    columns = non_overlapping_cols
     if debug > 0:
         print("NUM COLUMNS:", len(columns))
         print("EXTRA LINES BEFORE:", len(extra_lines))
@@ -262,10 +287,16 @@ def split_lines_on_column_gaps(text_region: pdm.PageXMLTextRegion,
             append_count += 1
     if debug > 0:
         print('append_count:', append_count)
-    extra_lines = non_col_lines
-    if debug > 0:
         print("EXTRA LINES AFTER:", len(extra_lines))
+    return non_col_lines
+
+
+def add_extra_text_regions(text_region: pdm.PageXMLTextRegion, columns: List[pdm.PageXMLColumn],
+                           extra_lines: List[pdm.PageXMLTextLine], min_gap_width: int,
+                           ignore_bad_coordinate_lines: bool, debug: int = 0):
+    """Create additional text regions for lines that are not assigned to any columns."""
     extra = None
+    extra_regions = []
     if len(extra_lines) > 0:
         try:
             coords = pdm.parse_derived_coords(extra_lines)
@@ -296,31 +327,61 @@ def split_lines_on_column_gaps(text_region: pdm.PageXMLTextRegion,
                     print('\t', text_region.id, text_region.stats)
                     print('\t', extra.id, extra.stats)
                     print('split_lines_on_column_gaps - cannot split text_region, returning text_region')
-                extra_cols = [extra]
+                extra_trs = [extra]
             elif all([extra_stat == tr_stat for extra_stat, tr_stat in zip(extra.stats, text_region.stats)]):
                 if debug > 0:
                     print('split_lines_on_column_gaps - extra equals text_region:')
                     print('\t', text_region.id, text_region.stats)
                     print('\t', extra.id, extra.stats)
                     print('split_lines_on_column_gaps - cannot split text_region, returning text_region')
-                extra_cols = [extra]
+                extra_trs = [extra]
             else:
-                extra_cols = split_lines_on_column_gaps(extra, min_gap_width, debug=debug)
-            for extra_col in extra_cols:
+                extra_trs = split_lines_on_column_gaps(extra, min_gap_width, debug=debug)
+            for extra_col in extra_trs:
                 if debug > 0:
                     print('\tEXTRA COL AFTER EXTRA SPLIT:', extra_col.stats)
                 extra_col.set_parent(text_region.parent)
                 if text_region.parent:
                     extra_col.set_derived_id(text_region.parent.id)
-            columns += extra_cols
+            extra_regions += extra_trs
             extra = None
     if extra is not None:
         print('source doc:', text_region.id)
         print(extra)
         raise TypeError(f'Extra is not None but {type(extra)}')
+    return extra_regions
+
+
+def split_lines_on_column_gaps(text_region: pdm.PageXMLTextRegion,
+                               min_column_lines: int = 2,
+                               min_gap_width: int = 20,
+                               min_column_width: int = 20,
+                               overlap_threshold: float = 0.5,
+                               ignore_bad_coordinate_lines: bool = True,
+                               debug: int = 0) -> List[pdm.PageXMLColumn]:
+    lines = [line for line in text_region.get_lines()]
+    if 'scan_id' not in text_region.metadata:
+        raise KeyError(f'no "scan_id" in text_region {text_region.id}')
+    column_ranges = find_column_ranges(lines, min_column_lines=min_column_lines, min_gap_width=min_gap_width,
+                                       min_column_width=min_column_width, debug=debug-1)
+    if debug > 0:
+        print('split_lines_on_column_gaps - text_region:', text_region.id, text_region.stats)
+        print("COLUMN RANGES:", column_ranges)
+    column_lines, extra_lines = sort_lines_on_column_ranges(text_region, lines, column_ranges,
+                                                            overlap_threshold, debug=debug)
+    columns = derive_column_from_lines(text_region, column_lines, debug=debug)
+    extra_lines = add_extra_lines_to_columns(text_region, columns, extra_lines, debug=debug)
+    extra_regions = add_extra_text_regions(text_region, columns, extra_lines, min_gap_width,
+                                           ignore_bad_coordinate_lines, debug=debug)
+    columns.extend(extra_regions)
     if debug > 3:
         print('\n------------\n')
         for col in columns:
-            print(f"split_lines_on_column_gaps - number of lines directly under column {col.id}: {len(col.lines)}")
+            print(f"split_lines_on_column_gaps - number of lines directly under column {col.id}: {len(col.get_lines())}")
         print('\n------------\n')
+    num_lines = [col.stats['lines'] for col in columns]
+    if sum(num_lines) != len(lines):
+        raise ValueError(f"Columns have a different number of lines ({' + '.join(num_lines)} = {sum(num_lines)}) "
+                         f"from text region ({len(lines)}). This is probably an issue with this function, rather "
+                         f"than with the input region.")
     return columns

--- a/pagexml/parsers/scan_parser.py
+++ b/pagexml/parsers/scan_parser.py
@@ -1,9 +1,12 @@
 import copy
+from collections import defaultdict
 from typing import List, Tuple
 
 import numpy as np
 
 import pagexml.model.physical_document_model as pdm
+import pagexml.helper.pagexml_helper as pagexml_helper
+import pagexml.parsers.column_parser as column_parser
 
 
 def set_average_scan_width(scans: List[pdm.PageXMLScan]):
@@ -16,23 +19,20 @@ def set_average_scan_width(scans: List[pdm.PageXMLScan]):
         scan.metadata['avg_scan_height'] = avg_height
 
 
-def get_page_split_widths(scan: pdm.PageXMLScan, page_overlap: int = 0) -> Tuple[int, int, int, int]:
+def get_page_split_widths(scan: pdm.PageXMLScan, separation_point: int = None, page_overlap: int = 0) -> Tuple[int, int, int, int]:
     if hasattr(scan, 'coords') is False or scan.coords is None or scan.coords.points is None:
         print(f'ERROR determining scan width in get_page_split_widths for scan {scan.id}')
-    scan_width = scan.coords.width
-    if 'avg_scan_width' in scan.metadata:
-        scan_width_ratio = scan.coords.width / scan.metadata['avg_scan_width']
-        if scan_width_ratio < 0.8 or scan_width_ratio > 1.25:
-            scan_width = scan.metadata['avg_scan_width']
     even_start = scan.coords.left
-    odd_end = scan_width
-    odd_start = scan_width / 2 - page_overlap
-    even_end = scan_width / 2 + page_overlap
+    odd_end = scan.coords.width
+    if separation_point is None:
+        separation_point = odd_end / 2
+    odd_start = separation_point - page_overlap
+    even_end = separation_point + page_overlap
     return even_start, int(even_end), int(odd_start), odd_end
 
 
 def initialize_pagexml_page(scan_doc: pdm.PageXMLScan, side: str,
-                            page_start: int, page_end: int) -> pdm.PageXMLPage:
+                            page_start: int, page_end: int, debug: int = 0) -> pdm.PageXMLPage:
     """Initialize a pagexml page type document based on the scan metadata."""
     metadata = copy.copy(scan_doc.metadata)
     if 'doc_type' in metadata:
@@ -55,17 +55,23 @@ def initialize_pagexml_page(scan_doc: pdm.PageXMLScan, side: str,
     metadata['scan_id'] = scan_doc.metadata['scan_id']
     points = [
         (region[0], region[1]), (region[2], region[1]),
-        (region[2], region[3]), (region[0], region[1])
+        (region[2], region[3]), (region[0], region[3])
     ]
+    if debug > 0:
+        print(f"scan_parser.initialize_pagexml_page - region: {region}")
+        print(f"scan_parser.initialize_pagexml_page - points: {points}")
     coords = pdm.Coords(points)
     page_doc = pdm.PageXMLPage(doc_id=metadata['page_id'], metadata=metadata, coords=coords,
                                text_regions=[])
     page_doc.set_parent(scan_doc)
+    if page_doc.id is None:
+        page_doc.set_derived_id(scan_doc.id)
     return page_doc
 
 
-def initialize_scan_pages(scan: pdm.PageXMLScan, page_overlap: int = 0):
-    even_start, even_end, odd_start, odd_end = get_page_split_widths(scan, page_overlap=page_overlap)
+def initialize_scan_pages(scan: pdm.PageXMLScan, separation_point: int = None, page_overlap: int = 0):
+    even_start, even_end, odd_start, odd_end = get_page_split_widths(scan, separation_point=separation_point,
+                                                                     page_overlap=page_overlap)
     page_even = initialize_pagexml_page(scan, 'even', even_start, even_end)
     page_odd = initialize_pagexml_page(scan, 'odd', odd_start, odd_end)
     pages = [page_even, page_odd]
@@ -77,8 +83,153 @@ def initialize_scan_pages(scan: pdm.PageXMLScan, page_overlap: int = 0):
     return pages
 
 
-def split_scan_pages(scan: pdm.PageXMLScan, page_overlap: int = 0):
-    pages = initialize_scan_pages(scan, page_overlap=page_overlap)
+def sort_docs_on_separation_point(docs: List[pdm.PageXMLDoc],
+                                  separation_point: int, doc_indent: int):
+    docs_left, docs_right, docs_mid = [], [], []
+    for doc in docs:
+        left, right = pagexml_helper.get_doc_indent_left_right(doc, doc_indent=doc_indent)
+        if left > separation_point:
+            docs_right.append(doc)
+        elif right < separation_point:
+            docs_left.append(doc)
+        else:
+            docs_mid.append(doc)
+    return docs_left, docs_right, docs_mid
+
+
+def get_parent_region(doc: pdm.PageXMLDoc):
+    if doc.parent is None:
+        return None
+    region_types = [pdm.PageXMLTextRegion, pdm.PageXMLTableRegion, pdm.PageXMLEmptyRegion]
+    parent = doc.parent
+    while parent is not None:
+        if any(isinstance(parent, region_type) for region_type in region_types):
+            return parent
+        parent = parent.parent
+    return None
+
+
+def group_lines_by_parent_regions(lines: List[pdm.PageXMLTextLine]):
+    trs = []
+    tr_lines = defaultdict(list)
+    for line in lines:
+        parent_region = get_parent_region(line)
+        tr_lines[parent_region].append(line)
+    for tr in tr_lines:
+        if isinstance(tr, pdm.PageXMLTextRegion):
+            new_tr = pagexml_helper.derive_text_region_from_lines(tr_lines[tr], parent=tr.parent)
+            assert isinstance(new_tr, pdm.PageXMLTextRegion), "region type changed"
+            new_tr.set_derived_id(tr.parent.id)
+            trs.append(new_tr)
+        elif isinstance(tr, pdm.PageXMLTableRegion):
+            new_table = pagexml_helper.derive_table_region_from_lines(tr_lines[tr])
+            assert isinstance(new_table, pdm.PageXMLTableRegion), "region type changed"
+            new_table.set_derived_id(tr.parent.id)
+            trs.append(new_table)
+        else:
+            raise TypeError(f"parent of line is neither PageXMLTextRegion nor "
+                            f"PageXMLTableRegion, but {tr.__class__.__name__}")
+    return trs
+
+
+def group_regions_by_column(regions: List[pdm.PageXMLRegion]):
+    """
+    for region in regions:
+        print(f"scan_parser.group_regions_by_column - region: {region.id} {region.__class__.__name__}")
+    """
+    columns = [column_parser.derive_column_from_regions(region) for region in regions]
+    return column_parser.normalise_columns(columns)
+
+
+def adjust_page_left(page: pdm.PageXMLPage, indent: int = 0):
+    """Adjust the left coordinate of a split page based on the left-most text region.
+    If the left point of a page is to the right of the left-most text region, adjust
+    the page left coordinate (and its width) to the left-most point of the left-most
+    region. Optionally, add an extra indent to create a left margin between the page
+    boundary and the left-most text region."""
+    trs = page.get_textual_regions()
+    if len(trs) == 0:
+        return None
+    text_left = min([tr.coords.left for tr in trs])
+    if page.coords.left > text_left - indent:
+        # old_box_string = page.coords.box_string
+        old_left = page.coords.left
+        new_left = text_left - indent
+        points = [p if p[0] != old_left else (new_left, p[1]) for p in page.coords.points]
+        page.coords = pdm.Coords(points=points)
+
+
+def split_scan_pages_with_separation_point(scan: pdm.PageXMLScan, separation_point: int,
+                                           doc_indent: int = 0):
+    """Split the text lines of a scan into verso and recto pages using a separation
+    (and an optional line indentation).
+
+    """
+    trs = [pagexml_helper.copy_region(tr) for tr in scan.get_regions()]
+    for tr in trs:
+        tr.parent = scan
+    trs_verso, trs_recto, trs_mid = sort_docs_on_separation_point(trs, separation_point,
+                                                                  doc_indent=doc_indent)
+    trs_mid_lines = [line for tr in trs_mid for line in tr.lines]
+    """
+    print(f"\nscan_parser.split_scan_pages_with_separation_points - BEFORE extending")
+    for region in trs_verso:
+        print(f"scan_parser.split_scan_pages_with_separation_points - "
+              f"verso region: {region.id} {region.__class__.__name__}")
+    for region in trs_mid:
+        print(f"scan_parser.split_scan_pages_with_separation_points - "
+              f"mid region: {region.id} {region.__class__.__name__}")
+    for region in trs_recto:
+        print(f"scan_parser.split_scan_pages_with_separation_points - "
+              f"recto region: {region.id} {region.__class__.__name__}")
+    """
+    lines_verso, lines_recto, lines_mid = sort_docs_on_separation_point(trs_mid_lines, separation_point,
+                                                                        doc_indent=doc_indent)
+    trs_verso.extend(group_lines_by_parent_regions(lines_verso))
+    trs_recto.extend(group_lines_by_parent_regions(lines_recto))
+    trs_mid = group_lines_by_parent_regions(lines_mid)
+    """
+    print(f"\nscan_parser.split_scan_pages_with_separation_points - AFTER extending")
+    for region in trs_verso:
+        print(f"scan_parser.split_scan_pages_with_separation_points - "
+              f"verso region: {region.id} {region.__class__.__name__}")
+    for region in trs_mid:
+        print(f"scan_parser.split_scan_pages_with_separation_points - "
+              f"mid region: {region.id} {region.__class__.__name__}")
+    for region in trs_recto:
+        print(f"scan_parser.split_scan_pages_with_separation_points - "
+              f"recto region: {region.id} {region.__class__.__name__}")
+    """
+    page_verso = initialize_pagexml_page(scan, 'verso', scan.coords.left, separation_point)
+    page_recto = initialize_pagexml_page(scan, 'recto', separation_point, scan.coords.right)
+    columns_verso = group_regions_by_column(trs_verso)
+    columns_recto = group_regions_by_column(trs_recto)
+    for col in columns_verso:
+        page_verso.add_child(col)
+    for col in columns_recto:
+        page_recto.add_child(col)
+    for tr in trs_mid:
+        overlap_verso = pdm.get_horizontal_overlap(page_verso, tr)
+        overlap_recto = pdm.get_horizontal_overlap(page_recto, tr)
+        col = page_verso.columns[-1] if overlap_verso > overlap_recto else page_recto.columns[0]
+        col.add_child(tr)
+    verso_lines = len(page_recto.get_lines())
+    recto_lines = len(page_verso.get_lines())
+    page_lines = sum([verso_lines, recto_lines])
+    if page_lines != scan.stats['lines']:
+        raise ValueError(f"number of lines in pages verso ({verso_lines}) and recto ({recto_lines}) "
+                         f"is not the same as in scan ({scan.stats['lines']}). This is probably an "
+                         f"error of this function. ")
+    adjust_page_left(page_verso)
+    adjust_page_left(page_recto)
+    if scan.coords.width < separation_point:
+        return page_verso, None
+    else:
+        return page_verso, page_recto
+
+
+def split_scan_pages(scan: pdm.PageXMLScan, separation_point: int = None, page_overlap: int = 0):
+    pages = initialize_scan_pages(scan, separation_point=separation_point, page_overlap=page_overlap)
     trs: List[pdm.PageXMLDoc] = []
     trs.extend(scan.text_regions)
     trs.extend(scan.table_regions)

--- a/pagexml/parsers/scan_parser.py
+++ b/pagexml/parsers/scan_parser.py
@@ -160,7 +160,7 @@ def adjust_page_left(page: pdm.PageXMLPage, indent: int = 0):
 
 
 def split_scan_pages_with_separation_point(scan: pdm.PageXMLScan, separation_point: int,
-                                           doc_indent: int = 0):
+                                           doc_indent: int = 0, debug: int = 0):
     """Split the text lines of a scan into verso and recto pages using a separation
     (and an optional line indentation).
 
@@ -171,35 +171,39 @@ def split_scan_pages_with_separation_point(scan: pdm.PageXMLScan, separation_poi
     trs_verso, trs_recto, trs_mid = sort_docs_on_separation_point(trs, separation_point,
                                                                   doc_indent=doc_indent)
     trs_mid_lines = [line for tr in trs_mid for line in tr.lines]
-    """
-    print(f"\nscan_parser.split_scan_pages_with_separation_points - BEFORE extending")
-    for region in trs_verso:
-        print(f"scan_parser.split_scan_pages_with_separation_points - "
-              f"verso region: {region.id} {region.__class__.__name__}")
-    for region in trs_mid:
-        print(f"scan_parser.split_scan_pages_with_separation_points - "
-              f"mid region: {region.id} {region.__class__.__name__}")
-    for region in trs_recto:
-        print(f"scan_parser.split_scan_pages_with_separation_points - "
-              f"recto region: {region.id} {region.__class__.__name__}")
-    """
+    if debug > 2:
+        print(f"\nscan_parser.split_scan_pages_with_separation_points - BEFORE extending")
+        print(f"    stats verso - trs: {len(trs_verso)}\tlines: {len([line for tr in trs_verso for line in tr.lines])}")
+        print(f"    stats recto - trs: {len(trs_recto)}\tlines: {len([line for tr in trs_recto for line in tr.lines])}")
+        print(f"    stats mid - trs: {len(trs_mid)}\tlines: {len([line for tr in trs_mid for line in tr.lines])}")
+        for region in trs_verso:
+            print(f"scan_parser.split_scan_pages_with_separation_points - "
+                  f"verso region: {region.id} {region.__class__.__name__}")
+        for region in trs_mid:
+            print(f"scan_parser.split_scan_pages_with_separation_points - "
+                  f"mid region: {region.id} {region.__class__.__name__}")
+        for region in trs_recto:
+            print(f"scan_parser.split_scan_pages_with_separation_points - "
+                  f"recto region: {region.id} {region.__class__.__name__}")
     lines_verso, lines_recto, lines_mid = sort_docs_on_separation_point(trs_mid_lines, separation_point,
                                                                         doc_indent=doc_indent)
     trs_verso.extend(group_lines_by_parent_regions(lines_verso))
     trs_recto.extend(group_lines_by_parent_regions(lines_recto))
     trs_mid = group_lines_by_parent_regions(lines_mid)
-    """
-    print(f"\nscan_parser.split_scan_pages_with_separation_points - AFTER extending")
-    for region in trs_verso:
-        print(f"scan_parser.split_scan_pages_with_separation_points - "
-              f"verso region: {region.id} {region.__class__.__name__}")
-    for region in trs_mid:
-        print(f"scan_parser.split_scan_pages_with_separation_points - "
-              f"mid region: {region.id} {region.__class__.__name__}")
-    for region in trs_recto:
-        print(f"scan_parser.split_scan_pages_with_separation_points - "
-              f"recto region: {region.id} {region.__class__.__name__}")
-    """
+    if debug > 2:
+        print(f"\nscan_parser.split_scan_pages_with_separation_points - AFTER extending")
+        print(f"    stats verso - trs: {len(trs_verso)}\tlines: {len([line for tr in trs_verso for line in tr.lines])}")
+        print(f"    stats recto - trs: {len(trs_recto)}\tlines: {len([line for tr in trs_recto for line in tr.lines])}")
+        print(f"    stats mid - trs: {len(trs_mid)}\tlines: {len([line for tr in trs_mid for line in tr.lines])}")
+        for region in trs_verso:
+            print(f"scan_parser.split_scan_pages_with_separation_points - "
+                  f"verso region: {region.id} {region.__class__.__name__}")
+        for region in trs_mid:
+            print(f"scan_parser.split_scan_pages_with_separation_points - "
+                  f"mid region: {region.id} {region.__class__.__name__}")
+        for region in trs_recto:
+            print(f"scan_parser.split_scan_pages_with_separation_points - "
+                  f"recto region: {region.id} {region.__class__.__name__}")
     page_verso = initialize_pagexml_page(scan, 'verso', scan.coords.left, separation_point)
     page_recto = initialize_pagexml_page(scan, 'recto', separation_point, scan.coords.right)
     columns_verso = group_regions_by_column(trs_verso)

--- a/tests/analysis_stats_test.py
+++ b/tests/analysis_stats_test.py
@@ -1,0 +1,83 @@
+from unittest import TestCase
+
+import pagexml.analysis.stats as stats
+import pagexml.parser as parser
+
+
+class TestInitStats(TestCase):
+
+    def setUp(self) -> None:
+        self.page_file = 'data/example.xml'
+        self.page_doc = parser.parse_pagexml_file(self.page_file)
+        self.tr = self.page_doc.text_regions[1]
+
+    def test_init_doc_stats_has_regions(self):
+        line_width_boundary_points = [100, 200]
+        doc_stats = stats._init_doc_stats(line_width_boundary_points=line_width_boundary_points)
+        print(doc_stats)
+        self.assertEqual(True, 'text_regions' in doc_stats)
+
+
+class TestDocStats(TestCase):
+
+    def setUp(self) -> None:
+        self.page_file = 'data/example.xml'
+        self.page_doc = parser.parse_pagexml_file(self.page_file)
+        self.tr = self.page_doc.text_regions[1]
+
+    def test_tr_metadata_has_coords_box_string(self):
+        metadata = stats.get_doc_metadata(self.tr)
+        self.assertEqual(self.tr.coords.box_string, metadata['doc_coords'])
+
+    def test_tr_line_stats_are_integers(self):
+        line_stats = stats.get_doc_line_stats(self.tr)
+        self.assertEqual(True, all(isinstance(line_stats[field], int) for field in line_stats))
+
+    def test_tr_word_stats_are_integers(self):
+        word_stats = stats.get_doc_word_stats(self.tr)
+        self.assertEqual(True, all(isinstance(word_stats[field], int) for field in word_stats if field != 'num_stop_words'))
+
+    def test_page_doc_metadata_has_coords_box_spage_docing(self):
+        metadata = stats.get_doc_metadata(self.page_doc)
+        self.assertEqual(self.page_doc.coords.box_string, metadata['doc_coords'])
+
+    def test_page_doc_line_stats_are_integers(self):
+        line_stats = stats.get_doc_line_stats(self.page_doc)
+        values = [line_stats[field] for field in line_stats]
+        self.assertEqual(True, all(isinstance(value, int) for value in values))
+
+    def test_page_doc_word_stats_are_integers(self):
+        word_stats = stats.get_doc_word_stats(self.page_doc)
+        values = [word_stats[field] for field in word_stats if field != 'num_stop_words']
+        self.assertEqual(True, all(isinstance(value, int) for value in values))
+
+    def test_page_doc_doc_stats_has_regions(self):
+        doc_stats = stats.get_doc_stats(self.page_doc)
+        self.assertEqual(True, 'text_regions' in doc_stats)
+
+    def test_region_level_same_as_region_list(self):
+        trs = [tr for tr in self.page_doc.get_inner_text_regions()]
+        trs_stats = stats.get_doc_stats(trs)
+        docs_stats = stats.get_doc_stats(self.page_doc, use_region_level=True)
+        self.assertEqual(len(trs_stats), len(docs_stats))
+        doc_line_stats = stats.get_doc_line_stats(self.page_doc)
+        doc_word_stats = stats.get_doc_word_stats(self.page_doc)
+        shared_fields = list(doc_line_stats.keys()) + list(doc_word_stats.keys())
+        for i, field in enumerate(shared_fields):
+            with self.subTest(i):
+                self.assertEqual(trs_stats[field], docs_stats[field])
+
+    def test_page_doc_old_doc_stats_same_as_new_doc_stats(self):
+        new_doc_stats = stats.get_doc_stats(self.page_doc)
+        old_doc_stats = stats.get_doc_stats_old(self.page_doc)
+        for field in new_doc_stats:
+            if field not in old_doc_stats:
+                print(f"missing in old: {field}")
+            elif old_doc_stats[field] != new_doc_stats[field]:
+                print(f"different values in old ({old_doc_stats[field]}) and new ({new_doc_stats[field]})")
+        for field in old_doc_stats:
+            if field not in new_doc_stats:
+                print(f"missing in new: {field}")
+        del new_doc_stats['chars']
+        del new_doc_stats['doc_coords']
+        self.assertEqual(new_doc_stats, old_doc_stats)

--- a/tests/helper-pagexml_helper_test.py
+++ b/tests/helper-pagexml_helper_test.py
@@ -58,8 +58,8 @@ class TestPageXMLHelper(unittest.TestCase):
     def test_element_overlap_same_points(self):
         tr1 = make_region([(1, 1)])
         tr2 = make_region([(1, 1)])
-        self.assertEqual(True, helper.regions_overlap(tr1, tr2))
-        self.assertEqual(True, helper.regions_overlap(tr2, tr1))
+        self.assertEqual(True, helper.regions_overlap(tr1, tr2, debug=10))
+        self.assertEqual(True, helper.regions_overlap(tr2, tr1, debug=10))
 
     def test_element_overlap_different_points(self):
         tr1 = make_region([(1, 1)])

--- a/tests/helper_spatial_helper_test.py
+++ b/tests/helper_spatial_helper_test.py
@@ -1,0 +1,97 @@
+from itertools import combinations
+from unittest import TestCase
+
+import pagexml.helper.spatial_helper as spatial_helper
+import pagexml.model.physical_document_model as pdm
+
+
+class TestSpatialHelper(TestCase):
+
+    def setUp(self) -> None:
+        self.coords_main = pdm.Coords([(0, 0), (500, 0), (500, 500), (0, 500)])
+        self.region_main = pdm.PageXMLTextRegion(doc_id='r1', coords=self.coords_main)
+        self.coords1 = pdm.Coords([(100, 100), (200, 100), (200, 200), (100, 200)])
+        self.region1 = pdm.PageXMLTextRegion(doc_id='r1', coords=self.coords1)
+        self.coords2 = pdm.Coords([(150, 150), (250, 150), (250, 250), (150, 250)])
+        self.region2 = pdm.PageXMLTextRegion(doc_id='r2', coords=self.coords2)
+        self.coords3 = pdm.Coords([(300, 100), (400, 100), (400, 200), (300, 200)])
+        self.region3 = pdm.PageXMLTextRegion(doc_id='r3', coords=self.coords3)
+        self.coords4 = pdm.Coords([(200, 100), (300, 100), (300, 200), (200, 200)])
+        self.region4 = pdm.PageXMLTextRegion(doc_id='r4', coords=self.coords4)
+        self.coords5 = pdm.Coords([(100, 200), (200, 200), (200, 300), (100, 300)])
+        self.region5 = pdm.PageXMLTextRegion(doc_id='r5', coords=self.coords5)
+
+    def test_region_1_and_2_overlap(self):
+        self.assertEqual(True, spatial_helper.regions_poly_overlap(self.region1, self.region2))
+
+    def test_region_1_and_2_relative_hloc(self):
+        self.assertEqual('over', spatial_helper.get_relative_hloc(self.region1, self.region2))
+
+    def test_region_1_and_2_relative_vloc(self):
+        self.assertEqual('over', spatial_helper.get_relative_vloc(self.region1, self.region2))
+
+    def test_region_1_and_3_not_overlap(self):
+        self.assertEqual(False, spatial_helper.regions_poly_overlap(self.region1, self.region3))
+
+    def test_region_1_and_3_relative_hloc(self):
+        self.assertEqual('right', spatial_helper.get_relative_hloc(self.region1, self.region3))
+
+    def test_region_1_and_3_relative_vloc(self):
+        self.assertEqual('over', spatial_helper.get_relative_vloc(self.region1, self.region3))
+
+    def test_region_1_and_3_not_touch(self):
+        self.assertEqual(False, spatial_helper.region_touches_right(self.region1, self.region3))
+
+    def test_region_1_and_4_touch(self):
+        self.assertEqual(True, spatial_helper.region_touches_right(self.region1, self.region4))
+
+    def test_region_1_and_4_relative_hloc(self):
+        self.assertEqual('right', spatial_helper.get_relative_hloc(self.region1, self.region4))
+
+    def test_region_1_and_4_relative_vloc(self):
+        self.assertEqual('over', spatial_helper.get_relative_vloc(self.region1, self.region4))
+
+    def test_region_3_and_4_touch(self):
+        self.assertEqual(True, spatial_helper.region_touches_right(self.region1, self.region4))
+
+    def test_region_1_and_5_touch(self):
+        self.assertEqual(True, spatial_helper.region_touches_below(self.region1, self.region5))
+
+    def test_region_1_and_5_relative_hloc(self):
+        self.assertEqual('over', spatial_helper.get_relative_hloc(self.region1, self.region5))
+
+    def test_region_1_and_5_relative_vloc(self):
+        self.assertEqual('below', spatial_helper.get_relative_vloc(self.region1, self.region5))
+
+    def test_make_neighour_regions_region_1(self):
+        neighbours = spatial_helper.make_region_neighbours(self.region1, self.region_main)
+        self.assertEqual(4, len(neighbours))
+
+    def test_make_empty_regions_region_1(self):
+        empty_regions = spatial_helper.make_empty_regions(self.region1, debug=1)
+        self.assertEqual(0, len(empty_regions))
+
+    def test_make_empty_regions_region_main_with_region_1(self):
+        self.region_main.text_regions = [self.region1]
+        empty_regions = spatial_helper.make_empty_regions(self.region_main, debug=1)
+        self.assertEqual(4, len(empty_regions))
+
+    def test_make_empty_regions_region_main_with_regions_1_3_(self):
+        self.region_main.text_regions = [self.region1, self.region3]
+        empty_regions = spatial_helper.make_empty_regions(self.region_main, debug=1)
+        self.assertEqual(5, len(empty_regions))
+
+    def test_make_empty_regions_region_main_with_regions_1_4_(self):
+        self.region_main.text_regions = [self.region1, self.region4]
+        empty_regions = spatial_helper.make_empty_regions(self.region_main, debug=1)
+        self.assertEqual(4, len(empty_regions))
+
+    def test_make_empty_regions_regions_do_not_overlap(self):
+        self.region_main.text_regions = [self.region1, self.region4]
+        empty_regions = spatial_helper.make_empty_regions(self.region_main, debug=1)
+        for r1, r2 in combinations(empty_regions, 2):
+            with self.subTest(f"{r1.id}-{r2.id}"):
+                overlap = spatial_helper.regions_box_overlap(r1, r2)
+                if overlap:
+                    print(f"OVERLAP: {r1.coords.box_string} - {r2.coords.box_string}")
+                self.assertEqual(False, overlap)

--- a/tests/model_basic_document_model_test.py
+++ b/tests/model_basic_document_model_test.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+import pagexml.model.physical_document_model as pdm
+
+
+class TestPhysicalStructureDoc(TestCase):
+
+    def setUp(self) -> None:
+        self.scan_id = "INST_ID_3209_0002"
+        self.coords = pdm.Coords([(10, 10), (20, 10), (20, 20), (10, 20)])
+        self.region = pdm.PageXMLRegion(doc_id='r1', coords=self.coords)
+
+    def test_set_derived_id_from_scan(self):
+        self.region.set_derived_id(self.scan_id)
+        self.assertEqual(f"{self.scan_id}-region-{self.coords.box_string}", self.region.id)
+
+    def test_set_derived_id_from_region(self):
+        parent_id = f"{self.scan_id}-page-0-0-400-400"
+        self.region.set_derived_id(parent_id)
+        self.assertEqual(f"{self.scan_id}-region-{self.coords.box_string}", self.region.id)

--- a/tests/model_physical_document_model.py
+++ b/tests/model_physical_document_model.py
@@ -1,0 +1,25 @@
+import unittest
+
+import pagexml.model.physical_document_model as pdm
+from pagexml.parser import parse_pagexml_file
+
+
+class TestParentage(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.scan_file = 'data/example-2.xml'
+        self.scan_doc = parse_pagexml_file(self.scan_file)
+        self.table_file = 'data/example_table.xml'
+        self.table_doc = parse_pagexml_file(self.table_file)
+
+    def test_get_parent_region_of_text_line(self):
+        tr = self.scan_doc.text_regions[1]
+        line = tr.lines[0]
+        parent = line.parent
+        self.assertEqual(tr, parent)
+
+    def test_get_parent_region_of_table_cell_line(self):
+        tr = self.table_doc.table_regions[0]
+        line = tr.rows[0].cells[1].lines[0]
+        parent = line.parent.parent.parent
+        self.assertEqual(tr, parent)

--- a/tests/parsers-column_parser_test.py
+++ b/tests/parsers-column_parser_test.py
@@ -1,7 +1,18 @@
 import unittest
+from typing import List
 
+import pagexml.helper.pagexml_helper as pagexml_helper
 import pagexml.model.physical_document_model as pdm
 import pagexml.parsers.column_parser as col_parser
+from pagexml.parser import parse_pagexml_file
+
+
+def generate_page_doc():
+    page_file = 'data/example.xml'
+    page_doc = parse_pagexml_file(page_file)
+    for region in page_doc.text_regions:
+        region.set_derived_id(page_doc.id)
+    return page_doc
 
 
 class TestPixelGap(unittest.TestCase):
@@ -38,7 +49,61 @@ class TestPixelGap(unittest.TestCase):
                                                       min_gap_width=50, min_column_width=150)
         self.assertEqual(0, len(column_ranges))
 
-    def test_find_column_gaps_returns_text_column_gap(self):
-        column_gaps = col_parser.find_column_gaps(self.lines, min_column_lines=1,
-                                                  min_gap_width=50, min_column_width=50)
-        self.assertEqual(1, len(column_gaps))
+
+def split_region_lines(text_region: pdm.PageXMLTextRegion) -> List[pdm.PageXMLColumn]:
+    lines_left, lines_right = [], []
+    print(f"text_region.id: #{text_region.id}#")
+    for line in text_region.lines:
+        if line.coords.left < 3500:
+            lines_left.append(line)
+        else:
+            lines_right.append(line)
+    tr_left = pagexml_helper.derive_text_region_from_lines(lines_left, parent=text_region.parent)
+    tr_right = pagexml_helper.derive_text_region_from_lines(lines_right, parent=text_region.parent)
+    col_left = col_parser.derive_column_from_regions(tr_left)
+    col_right = col_parser.derive_column_from_regions(tr_right)
+    columns = [col_left, col_right]
+    return columns
+
+
+class TestColumnGeneration(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.page_doc = generate_page_doc()
+
+    def test_generate_column_from_regions_copies_all_text_regions(self):
+        column = col_parser.derive_column_from_regions(self.page_doc.text_regions)
+        self.assertEqual(len(self.page_doc.text_regions), len(column.text_regions))
+
+    def test_generate_column_from_region_sets_scan_as_parent(self):
+        region = self.page_doc.text_regions[0]
+        column = col_parser.derive_column_from_regions(region)
+        self.assertEqual(self.page_doc, column.parent)
+
+    def test_generate_column_from_region_sets_columns_as_parent(self):
+        region = self.page_doc.text_regions[0]
+        column = col_parser.derive_column_from_regions(region)
+        self.assertEqual(column, column.text_regions[0].parent)
+
+    def test_generate_column_from_region_leaves_original_region_parent_intact(self):
+        region = self.page_doc.text_regions[0]
+        col_parser.derive_column_from_regions(region)
+        self.assertEqual(self.page_doc, region.parent)
+
+
+class TestColumnNormalisation(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.page_doc = generate_page_doc()
+        self.columns = [col_parser.derive_column_from_regions(r) for r in self.page_doc.text_regions]
+
+    def test_normalise_columns_retains_number_of_text_regions(self):
+        num_page_regions = len(self.page_doc.text_regions)
+        norm_columns = col_parser.normalise_columns(self.columns)
+        num_norm_regions = sum(len(col.text_regions) for col in norm_columns)
+        self.assertEqual(num_page_regions, num_norm_regions)
+
+    def test_normalise_columns_copies(self):
+        columns = split_region_lines(self.page_doc.text_regions[1])
+        norm_columns = col_parser.normalise_columns(columns)
+        self.assertEqual(1, len(norm_columns))

--- a/tests/parsers-scan_parser_test.py
+++ b/tests/parsers-scan_parser_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pagexml.model.pagexml_document_model as pdm
 import pagexml.parsers.scan_parser as scan_parser
 from pagexml.parser import parse_pagexml_file
 
@@ -40,3 +41,51 @@ class TestScanSplit(unittest.TestCase):
         page_overlap = 100
         pages = scan_parser.split_scan_pages(self.scan_doc, page_overlap=page_overlap)
         self.assertEqual(2, len(pages))
+
+
+class TestScanParser(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.scan_file = 'data/example-2.xml'
+        self.scan_doc = parse_pagexml_file(self.scan_file)
+        self.table_file = 'data/example_table.xml'
+        self.table_doc = parse_pagexml_file(self.table_file)
+        """
+        print(f"scan.id: {self.scan_doc.id}")
+        for tr in self.scan_doc.text_regions:
+            print(f"  tr.id: {tr.id}")
+        print(f"table.id: {self.table_doc.id}")
+        for tr in self.table_doc.table_regions:
+            print(f"  tr.id: {tr.id}")
+            for row in tr.rows:
+                print(row.cells[1].lines[0].parent)
+                print(f"    row {row.id}: {[line.text for cell in row.cells for line in cell.lines]}")
+        """
+
+    def test_separation_split_returns_non_overlapping_pages(self):
+        page_verso, page_recto = scan_parser.split_scan_pages_with_separation_point(self.scan_doc, 2700)
+        hor_overlap = pdm.get_horizontal_overlap(page_verso, page_recto)
+        self.assertEqual(0, hor_overlap)
+
+    def test_separation_split_adjusts_page_left_to_left_most_region(self):
+        page_verso, page_recto = scan_parser.split_scan_pages_with_separation_point(self.scan_doc, 3100)
+        tr_left = min(tr.coords.left for tr in page_recto.get_textual_regions())
+        self.assertEqual(tr_left, page_recto.coords.left)
+
+    def test_get_parent_region_of_text_line(self):
+        tr = self.scan_doc.text_regions[1]
+        line = tr.lines[0]
+        parent = scan_parser.get_parent_region(line)
+        self.assertEqual(tr, parent)
+
+    def test_get_parent_region_of_table_cell_line(self):
+        tr = self.table_doc.table_regions[0]
+        line = tr.rows[0].cells[1].lines[0]
+        parent = scan_parser.get_parent_region(line)
+        self.assertEqual(tr, parent)
+
+    def test_group_lines_by_parent_regions_retains_table_structure(self):
+        table = self.table_doc.table_regions[0]
+        lines = [line for row in table.rows for cell in row.cells for line in cell.lines]
+        new_tables = scan_parser.group_lines_by_parent_regions(lines)
+        self.assertEqual(table.stats['lines'], new_tables[0].stats['lines'])

--- a/tests/pdm_xml_test.py
+++ b/tests/pdm_xml_test.py
@@ -38,3 +38,12 @@ class TestPageXMLWord(TestCase):
         doc_pagexml = col.to_pagexml()
         col_xml = doc_pagexml.find(f".//{xml.PAGE + 'TextRegion'}")
         self.assertEqual('column', col_xml.attrib['type'])
+
+    def test_page_can_export_to_valid_pagexml(self) -> None:
+        coords = pdm.Coords([(10, 10), (20, 10), (20, 20), (20, 10)])
+        col = pdm.PageXMLColumn(doc_id='col-1', coords=coords)
+        page = pdm.PageXMLPage(doc_id='page-1', columns=[col])
+        page.add_child(col)
+        doc_pagexml = page.to_pagexml()
+        page_xml = doc_pagexml.find(f".//{xml.PAGE + 'TextRegion'}")
+        self.assertEqual('page', page_xml.attrib['type'])


### PR DESCRIPTION
Improvements:
- Add function `pagexml.analysis.stats.get_doc_region_stats` to get statistics for regions below scan-level.
- Add function `pagexml.parsers.scan_parser.split_scan_pages_with_separation_point` to split a scan instance into two page instances using a separation point.
- Add functions in `pagexml.helper.spatial_helper` to check whether two regions touch each other without overlapping.
- Add generic `PageXMLRegion` base class to the PageXML Document Model and make `PageXMLTextRegion`, `PageXMLTableRegion` and `PageXMLEmptyRegion` inherit from this base class. This simplifies selecting either all regions or only regions of a specific type.
- Add class `PageXMLEmptyRegion` to generate empty regions (to make explicit which regions of a scan or page are empty).
- Improve copying PageXMLDoc objects to avoid copying parents. This makes copying much faster and avoids generating stray objects.
- Improve merging of columns via `pagexml.parsers.column_parser.merge_columns` (including overlapping columns via `column_parser.normalise_columns`) to properly carry over metadata and group text lines in a `PageXMLTextRegion` object, so that the columns no longer have `PageXMLTextLine`s as direct children.

Bug fixes:
- Fix bug generating Coords for points that have either zero width or zero height.
- Fix bug in `set_parentage` that skipped new region types.
- Fix bug in `pagexml.parser` functions `json_to_pagexml_column`, `json_to_pagexml_page` and `json_to_pagexml_scan` that ignored PageXMLTableRegion elements.