### PR TITLE
Empty regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,31 @@ functionality to support a range of tasks:
 - reinterpreting and restructuring text regions and lines ([tutorial](./notebooks/Demo-restructuring-documents.ipynb)),
 - turning physical structure into logical structure,
 
+### Using PageXML-tools in R:
+
+```aiignore
+#Python
+# run in CMD (Command) first (first time only): 
+py -m pip install pagexml-tools
+# Install and start Python 3.11 in background 
+```
+
+```aiignore
+# R
+# run in different window in R first time only! 
+install.packages("reticulate")
+# run in different window in R first: 
+library(reticulate)
+# run in different window in R next: 
+py_require(c("pagexml-tools")) 
+
+# Import PageXML file parser:
+
+from pagexml.parser import parse_pagexml_file
+```
+
+Thanks to Milan van Lange for this R example.
+
 ----
 
 [USAGE](https://pagexml.readthedocs.io/en/latest/) |

--- a/pagexml/helper/pagexml_helper.py
+++ b/pagexml/helper/pagexml_helper.py
@@ -117,14 +117,22 @@ def sort_regions_in_reading_order(doc: pdm.PageXMLDoc) -> List[pdm.PageXMLTextRe
         return []
 
 
-def horizontal_group_lines(lines: List[pdm.PageXMLTextLine],
+def horizontal_group_lines(lines: List[pdm.PageXMLTextLine], text_only: bool = True,
                            debug: int = 0) -> List[List[pdm.PageXMLTextLine]]:
     """Sort lines of a text region vertically as a list of lists,
     with adjacent lines grouped in inner lists."""
+    if text_only is True:
+        lines = [line for line in lines if line.text is not None]
     if len(lines) == 0:
         return []
     # First, sort lines vertically
-    vertically_sorted = [line for line in sorted(lines, key=lambda line: line.baseline.top) if line.text is not None]
+    if all(line.baseline is not None for line in lines):
+        vertically_sorted = [line for line in sorted(lines, key=lambda line: line.baseline.top)]
+    elif all(line.coords is not None for line in lines):
+        vertically_sorted = [line for line in sorted(lines, key=lambda line: line.coords.top)]
+    else:
+        missing = [line.id for line in lines if line.coords is None]
+        raise AttributeError(f"Cannot horizontally group lines because some lines have no coordinates:\n\t{missing}")
     if len(vertically_sorted) == 0:
         # for line in lines:
         #     print(line.coords.box, line.text)

--- a/pagexml/helper/spatial_helper.py
+++ b/pagexml/helper/spatial_helper.py
@@ -148,7 +148,16 @@ def get_regions_horizontal_over_line(line: pdm.Coords,
     return [tr for tr in text_regions if line_and_region_align_horizontally(line, tr)]
 
 
-def make_empty_region(left: int, top: int, right: int, bottom: int, region_id: str):
+def make_empty_region(left: int, top: int, right: int, bottom: int, region_id: str,
+                      context_doc: pdm.PageXMLRegion):
+    if left < context_doc.coords.left:
+        left = context_doc.coords.left
+    if top < context_doc.coords.top:
+        top = context_doc.coords.top
+    if right > context_doc.coords.right:
+        right = context_doc.coords.right
+    if bottom > context_doc.coords.bottom:
+        bottom = context_doc.coords.bottom
     coords = pdm.Coords([
         (left, top), (right, top), (right, bottom), (left, bottom)
     ])
@@ -156,7 +165,7 @@ def make_empty_region(left: int, top: int, right: int, bottom: int, region_id: s
 
 
 def make_region_neighbours(inner_region: pdm.PageXMLRegion, outer_region: pdm.PageXMLRegion,
-                           debug: int = 0):
+                           context_doc: pdm.PageXMLRegion, debug: int = 0):
     neighbour_regions = []
     ic = inner_region.coords
     oc = outer_region.coords
@@ -164,56 +173,74 @@ def make_region_neighbours(inner_region: pdm.PageXMLRegion, outer_region: pdm.Pa
         print(f"inner.coords: {ic.box}")
         print(f"outer.coords: {oc.box}")
     # check if we need to make an above region
-    if inner_region.coords.top > outer_region.coords.top:
-        above_region = make_empty_region(oc.left, oc.top, oc.right, ic.top, region_id=f'above_{inner_region.id}')
-        neighbour_regions.append(above_region)
-    # check if we need to make a below region
-    if inner_region.coords.bottom < outer_region.coords.bottom:
-        below_region = make_empty_region(oc.left, ic.bottom, oc.right, oc.bottom, region_id=f'below_{inner_region.id}')
-        neighbour_regions.append(below_region)
-    # check if we need to make a left region
-    if inner_region.coords.left > outer_region.coords.left:
-        left_region = make_empty_region(oc.left, ic.top, ic.left, ic.bottom, region_id=f'left_{inner_region.id}')
-        neighbour_regions.append(left_region)
-    # check if we need to make a right region
-    if inner_region.coords.right < outer_region.coords.right:
-        right_region = make_empty_region(ic.right, ic.top, oc.right, ic.bottom, region_id=f'right_{inner_region.id}')
-        neighbour_regions.append(right_region)
+    try:
+        if ic.top > oc.top:
+            above_region = make_empty_region(oc.left, oc.top, oc.right, ic.top,
+                                             region_id=f'above_{inner_region.id}', context_doc=context_doc)
+            neighbour_regions.append(above_region)
+        # check if we need to make a below region
+        if ic.bottom < oc.bottom:
+            below_region = make_empty_region(oc.left, ic.bottom, oc.right, oc.bottom,
+                                             region_id=f'below_{inner_region.id}', context_doc=context_doc)
+            neighbour_regions.append(below_region)
+        # check if we need to make a left region
+        if ic.left > oc.left:
+            left_region = make_empty_region(oc.left, ic.top, ic.left, ic.bottom,
+                                            region_id=f'left_{inner_region.id}', context_doc=context_doc)
+            neighbour_regions.append(left_region)
+        # check if we need to make a right region
+        if ic.right < oc.right:
+            right_region = make_empty_region(ic.right, ic.top, oc.right, ic.bottom,
+                                             region_id=f'right_{inner_region.id}', context_doc=context_doc)
+            neighbour_regions.append(right_region)
+    except BaseException:
+        print(f"inner_region: {inner_region.id}, outer_region: {outer_region.id},")
+        print(f"ValueError: inner_coords: {ic.box} outer_coords: {oc.box}")
+        raise
+    for nr in neighbour_regions:
+        nr.set_derived_id(context_doc.id)
     return neighbour_regions
 
 
 def make_empty_regions(doc: pdm.PageXMLTextRegion, debug: int = 0):
-    if len(doc.lines) > 0:
-        return []
-    if len(doc.text_regions) == 0:
-        return []
+    lines = doc.get_lines()
     empty_region = make_empty_region(doc.coords.left, doc.coords.top,
                                      doc.coords.right, doc.coords.bottom,
-                                     f"empty_{doc.id}")
+                                     f"empty_{doc.id}", doc)
+    if len(doc.get_textual_regions()) == 0 and len(doc.get_lines()) == 0:
+        return [empty_region]
+    if len(doc.get_textual_regions()) == 0 and len(doc.get_lines()) > 0:
+        non_overlapping_regions = [pdm.PageXMLTextRegion(lines=doc.get_lines(), coords=pdm.parse_derived_coords([doc]))]
+    else:
+        non_overlapping_regions: List[pdm.PageXMLRegion] = [tr for tr in doc.get_textual_regions()]
     region_exists = set()
     candidate_regions = [empty_region]
-    non_overlapping_regions: List[pdm.PageXMLRegion] = [tr for tr in doc.text_regions]
     region_exists.add(empty_region.coords.box_string)
     empty_regions = []
     if debug > 0:
-        print(f"initial doc: {doc.id}, candidate_regions: {len(candidate_regions)}, empty: {len(empty_regions)}")
+        print(f"make_empty_regions - initial doc: {doc.id}, candidate_regions: {len(candidate_regions)}, empty: {len(empty_regions)}")
     while len(candidate_regions) > 0:
         candidate_region = candidate_regions.pop(0)
         overlapping_regions = [tr for tr in non_overlapping_regions if regions_box_overlap(tr, candidate_region, debug=debug)]
         if len(overlapping_regions) == 0:
             if debug > 0:
                 cr = candidate_region
-                print(f"adding empty region: {cr.id} {cr.coords.box_string}")
+                print(f"make_empty_regions - adding empty region: {cr.id} {cr.coords.box_string}")
             empty_regions.append(candidate_region)
             non_overlapping_regions.append(candidate_region)
         else:
             tr = overlapping_regions[0]
-            new_regions = make_region_neighbours(tr, candidate_region)
+            try:
+                new_regions = make_region_neighbours(tr, candidate_region, doc)
+            except BaseException:
+                print(f"ValueError: doc {doc.id}, tr {tr.id}, candidate_region {candidate_region.id}")
+                raise
             candidate_regions.extend(new_regions)
         if debug > 0:
-            print(f"current candidate: {candidate_region.id}, {candidate_region.coords.box_string} "
-                  f"candidate_regions: {len(candidate_regions)}, "
-                  f"empty: {len(empty_regions)}")
+            print(f"make_empty_regions - current candidate: {candidate_region.id}, {candidate_region.coords.box_string} "
+                  f"    candidate_regions: {len(candidate_regions)}, "
+                  f"    empty: {len(empty_regions)}")
             for cr in candidate_regions:
                 print(f"\tcandidate: {cr.id}\t{cr.coords.box_string}")
+    empty_regions = [er for er in empty_regions if er.area > 0]
     return empty_regions

--- a/pagexml/model/pagexml_document_model.py
+++ b/pagexml/model/pagexml_document_model.py
@@ -241,16 +241,27 @@ class PageXMLTextLine(PageXMLDoc):
 
     def is_below(self, other: PageXMLTextLine, direct_only: bool = True) -> bool:
         """Test if the baseline of this line is directly below the baseline of the other line."""
-        # if there is no horizontal overlap, this line is not directly below the other
-        if direct_only and not get_horizontal_overlap(self, other):
-            # print("pagexml.pdm - NO HORIZONTAL OVERLAP")
+        self_top, self_bottom = get_line_top_bottom(self)
+        other_top, other_bottom = get_line_top_bottom(other)
+        vertical_overlap = min(self_bottom, other_bottom) - max(self_top, other_top)
+        horizontal_overlap = get_horizontal_overlap(self, other)
+        min_height = min(self_bottom - self_top, other_bottom - other_top)
+
+        if vertical_overlap / min_height > 0.5:
+            # print("pagexml.pdm - SELF IS ADJACENT TO OTHER")
             return False
-        if not direct_only and not get_horizontal_overlap(self, other):
-            vertical_overlap = get_vertical_overlap(self, other)
-            min_height = min(self.text_height, other.text_height)
-            if vertical_overlap / min_height > 0.5:
-                # print("pagexml.pdm - NO HORIZONTAL OVERLAP, LINES VERTICALLY OVERLAP")
-                return False
+
+        # if there is no horizontal overlap, this line is not directly below the other
+        if direct_only and horizontal_overlap == 0:
+            # print("pagexml.pdm - NO HORIZONTAL OVERLAP, NOT DIRECTLY BELOW")
+            return False
+
+        return self_top > other_top
+        """
+        if has_baseline(self) and has_baseline(other):
+            return baseline_is_below(self.baseline, other.baseline)
+        else:
+            sc, oc = self.coords, other.coords
         # if the bottom of this line is above the top of the other line, this line is above the other
         if self.baseline.bottom < other.baseline.top:
             # print("pagexml.pdm - BOTTOM OF SELF IS ABOVE TOP OF OTHER")
@@ -260,8 +271,8 @@ class PageXMLTextLine(PageXMLDoc):
         if baseline_is_below(self.baseline, other.baseline):
             # print("pagexml.pdm - BASELINE OF SELF IS BELOW BASELINE OF OTHER")
             return True
-        # print("pagexml.pdm - SELF IS ADJACENT TO OTHER")
         return False
+        """
 
     def is_next_to(self, other: PageXMLTextLine, debug: int = 0) -> bool:
         """Test if this line is vertically aligned with the other line."""
@@ -1321,14 +1332,14 @@ def get_horizontal_overlap(doc1: PageXMLDoc, doc2: PageXMLDoc, debug: int = 0) -
 
 def get_line_top_bottom(line: PageXMLTextLine):
     if has_baseline(line):
-        line_bottom = line.baseline.bottom
         line_height = line.xheight if line.xheight else int(line.coords.height / 2)
         line_top = line.baseline.top - line_height
+        line_bottom = line.baseline.bottom
     else:
         # assume the box cut around a line has 25% of its height below
         # the baseline
-        line_bottom = line.coords.bottom - line.coords.height * 0.25
         line_top = line.coords.top + line.coords.height * 0.25
+        line_bottom = line.coords.bottom - line.coords.height * 0.25
     return line_top, line_bottom
 
 

--- a/pagexml/parser.py
+++ b/pagexml/parser.py
@@ -4,6 +4,7 @@ import os
 import re
 from collections import defaultdict
 from datetime import datetime
+from pathlib import Path
 from typing import Dict, Generator, Iterable, List, Tuple, Union
 from xml.parsers import expat
 
@@ -520,21 +521,21 @@ def parse_pagexml_files(pagexml_files: List[str],
                 raise
 
 
-def read_pagexml_dirs(pagexml_dirs: Union[str, List[str]]) -> List[str]:
+def read_pagexml_dirs(pagexml_dirs: Union[Union[str, Path], List[Union[str, Path]]]) -> List[str]:
     """Return a list of all (Page)XML files within a list of directories.
 
     :param pagexml_dirs: a list of directories containing PageXML files.
     :type pagexml_dirs: Union[str, List[str]]
     """
     pagexml_files = []
-    if isinstance(pagexml_dirs, str):
+    if not isinstance(pagexml_dirs, list):
         pagexml_dirs = [pagexml_dirs]
     for pagexml_dir in pagexml_dirs:
         pagexml_files += glob.glob(pagexml_dir + "**/*.xml", recursive=True)
     return pagexml_files
 
 
-def parse_pagexml_files_from_directory(pagexml_directories: Union[str, List[str]],
+def parse_pagexml_files_from_directory(pagexml_directories: Union[Union[str, Path], List[Union[str, Path]]],
                                        show_progress: bool = False) -> Generator[pdm.PageXMLScan, None, None]:
     """Parse PageXML files from one or more directories.
 
@@ -545,7 +546,7 @@ def parse_pagexml_files_from_directory(pagexml_directories: Union[str, List[str]
     :return: a generator that yields a tuple of archived file name and content
     :rtype: Generator[Tuple[str, str], None, None]
     """
-    if isinstance(pagexml_directories, str):
+    if not isinstance(pagexml_directories, list):
         pagexml_directories = [pagexml_directories]
     for pagexml_directory in pagexml_directories:
         # print('dir:', pagexml_directory)

--- a/pagexml/parsers/scan_parser.py
+++ b/pagexml/parsers/scan_parser.py
@@ -165,6 +165,12 @@ def split_scan_pages_with_separation_point(scan: pdm.PageXMLScan, separation_poi
     (and an optional line indentation).
 
     """
+    if separation_point > scan.coords.width:
+        # if the separation point is higher than the width of the scan,
+        # there is no recto page, only a verso page. Set the separation
+        # point to the width of the scan so that the page will have the
+        # same dimensions.
+        separation_point = scan.coords.width
     trs = [pagexml_helper.copy_region(tr) for tr in scan.get_regions()]
     for tr in trs:
         tr.parent = scan
@@ -226,7 +232,7 @@ def split_scan_pages_with_separation_point(scan: pdm.PageXMLScan, separation_poi
                          f"error of this function. ")
     adjust_page_left(page_verso)
     adjust_page_left(page_recto)
-    if scan.coords.width < separation_point:
+    if scan.coords.width <= separation_point:
         return page_verso, None
     else:
         return page_verso, page_recto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 packages = [{ include = "pagexml" }]
 
 [tool.poetry.dependencies]
-python = ">=3.9 <4.0"
+python = ">=3.10 <4.0"
 fuzzy-search = "^2.4.5"
 numpy = ">=1.26 <3.0"
 py7zr = "^0.20.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,14 @@ packages = [{ include = "pagexml" }]
 [tool.poetry.dependencies]
 python = ">=3.9 <4.0"
 fuzzy-search = "^2.4.5"
-numpy = ">=1.26"
+numpy = ">=1.26 <3.0"
 py7zr = "^0.20.2"
 python-dateutil = "^2.8.2"
 pyyaml = "^6.0"
 scipy = ">=1.7"
 tqdm = "^4.64.1"
 xmltodict = "^0.13.0"
-shapely = "^2.0.3"
+shapely = ">=2.1.0"
 lxml = "^5.3.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/helper_spatial_helper_test.py
+++ b/tests/helper_spatial_helper_test.py
@@ -65,7 +65,7 @@ class TestSpatialHelper(TestCase):
         self.assertEqual('below', spatial_helper.get_relative_vloc(self.region1, self.region5))
 
     def test_make_neighour_regions_region_1(self):
-        neighbours = spatial_helper.make_region_neighbours(self.region1, self.region_main)
+        neighbours = spatial_helper.make_region_neighbours(self.region1, self.region_main, self.region_main)
         self.assertEqual(4, len(neighbours))
 
     def test_make_empty_regions_region_1(self):

--- a/tests/helper_spatial_helper_test.py
+++ b/tests/helper_spatial_helper_test.py
@@ -20,6 +20,7 @@ class TestSpatialHelper(TestCase):
         self.region4 = pdm.PageXMLTextRegion(doc_id='r4', coords=self.coords4)
         self.coords5 = pdm.Coords([(100, 200), (200, 200), (200, 300), (100, 300)])
         self.region5 = pdm.PageXMLTextRegion(doc_id='r5', coords=self.coords5)
+        self.line = pdm.PageXMLTextLine(coords=pdm.Coords([(100, 100), (200, 100)]))
 
     def test_region_1_and_2_overlap(self):
         self.assertEqual(True, spatial_helper.regions_poly_overlap(self.region1, self.region2))
@@ -69,7 +70,7 @@ class TestSpatialHelper(TestCase):
 
     def test_make_empty_regions_region_1(self):
         empty_regions = spatial_helper.make_empty_regions(self.region1, debug=1)
-        self.assertEqual(0, len(empty_regions))
+        self.assertEqual(1, len(empty_regions))
 
     def test_make_empty_regions_region_main_with_region_1(self):
         self.region_main.text_regions = [self.region1]
@@ -95,3 +96,8 @@ class TestSpatialHelper(TestCase):
                 if overlap:
                     print(f"OVERLAP: {r1.coords.box_string} - {r2.coords.box_string}")
                 self.assertEqual(False, overlap)
+
+    def test_make_empty_regions_region_main_with_line(self):
+        self.region_main.text_regions = [self.line]
+        empty_regions = spatial_helper.make_empty_regions(self.region_main, debug=1)
+        self.assertEqual(1, len(empty_regions))


### PR DESCRIPTION
Changes:
- bump shapely version to 2.1.0 to allow for numpy 2
- Remove 3.9 from accepted Python versions, because shapely 2.1.0 requires>= 3.10.

Improvements:
- Update `horizontal_group_lines` to use baselines when available, otherwise fall back to coords.
- Update `make_empty_regions` to constrain empty regions to be within the bounding box of the context document, regardless of whether content regions go outside of the context document.
- Add filter to `make_empty_regions` to remove regions with zero width or zero height.
- Update `PageXMLTextLine.is_below` to use a more precise text height (using the baseline when given) in determining vertical overlap.
- Update `parse_pagexml_files_from_directory` and `read_pagexml_dires` of PageXML parser to allow directories to be passed as `pathlib.Path` instances as well as strings.
- Add usage in R to README

Bug fixes:
- Fix bug in `make_empty_regions` that returns nothing for an empty context document. Now, it returns a single empty region with the same bounding box as the context document.
- Fix bug in `scan_parser.split_scan_pages_with_separation_point` that allows a single page to be wider than the original scan. Now if the separation x-coordinate is beyond the width of the scan, the derived page has the same width as the scan.

